### PR TITLE
Update emulator start command

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -77,9 +77,8 @@ const startEmulator = (ext: Extension) => async () => {
   ext.terminal.sendText(
     [
       ext.config.flowCommand,
-      `project`,
-      `start-emulator`,
-      `--config-path=${configPath}`,
+      `emulator`,
+      `--config-path="${configPath}"`,
       `--verbose`,
     ].join(" ")
   );


### PR DESCRIPTION
Closes #60 

## Description

- Updates the emulator start command to move away from the deprecated `flow project` version
- Fixes the issue where the emulator fails to start if the project path contains spaces

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
