### PR TITLE
Initialize global Flow CLI config

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,15 +99,6 @@ export async function activate (ctx: ExtensionContext): Promise<void> {
 }
 
 async function promptInitializeConfig (): Promise<boolean> {
-  let rootPath: string | undefined
-  if ((workspace.workspaceFolders != null) && (workspace.workspaceFolders.length > 0)) {
-    rootPath = workspace.workspaceFolders[0].uri.fsPath
-  } else {
-    rootPath = workspace.rootPath // ref: deprecated
-  }
-  if (rootPath === undefined) {
-    return false
-  }
 
   const continueMessage = 'Continue'
   const selection = await window.showInformationMessage('Missing Flow CLI configuration. Create a new one?', continueMessage)
@@ -115,7 +106,7 @@ async function promptInitializeConfig (): Promise<boolean> {
     return false
   }
 
-  await exec('flow init', { cwd: rootPath })
+  await exec('flow init --global')
 
   return true
 }


### PR DESCRIPTION
## Description

When the extension is launched, and the configuration is read, but is missing, a prompt is presented to initialize the configuration.

However, if a Cadence file is opened without a workspace, there is no workspace path, the extension fails to create a configuration (does not even prompt), and silently does nothing.

Always initialize a global configuration and ignore if a workspace is available or not. 
This is likely the best out-of-the box behaviour for new developers.

@sideninja this won't quite work yet, as once the config is created, it is found via `workspace.findFiles('flow.json')`.
Could we add a CLI command that simply prints the path to the config file it will use? It would return nothing if no config file (global or local) exists.
That way we could replace the function with e.g 
```js
let path = await exec('flow print-config-path')
if (path.length <= 0) { return false } 
this.configPath = path
```

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
