### PR TITLE
Copy active account to clipboard

### DIFF
--- a/extension/src/commands/command-constants.ts
+++ b/extension/src/commands/command-constants.ts
@@ -12,3 +12,6 @@ export const SEND_TRANSACTION = 'cadence.sendTransaction'
 
 // Command identifires for dependencies
 export const CHECK_DEPENDENCIES = 'cadence.checkDepencencies'
+
+// Copy active account to clipboard
+export const COPY_ACTIVE_ACCOUNT = 'cadence.copyActiveAccount'

--- a/extension/src/commands/command-controller.ts
+++ b/extension/src/commands/command-controller.ts
@@ -30,6 +30,7 @@ export class CommandController {
     this.#registerCommand(commandID.CREATE_ACCOUNT, this.#createAccount)
     this.#registerCommand(commandID.SWITCH_ACCOUNT, this.#switchActiveAccount)
     this.#registerCommand(commandID.CHECK_DEPENDENCIES, this.#checkDependencies)
+    this.#registerCommand(commandID.COPY_ACTIVE_ACCOUNT, this.#copyActiveAccount)
   }
 
   #restartServer (): void {
@@ -50,6 +51,10 @@ export class CommandController {
 
   #switchActiveAccount (): void {
     void ext.emulatorCtrl.switchActiveAccount()
+  }
+
+  #copyActiveAccount (): void {
+    void ext.emulatorCtrl.copyActiveAccount()
   }
 
   #checkDependencies (): void {

--- a/extension/src/emulator/emulator-controller.ts
+++ b/extension/src/emulator/emulator-controller.ts
@@ -118,12 +118,12 @@ export class EmulatorController {
   copyActiveAccount (): void {
     const activeAccount = this.#accountManager.getActiveAccount()
     if (activeAccount !== null) {
-      env.clipboard.writeText(`${activeAccount.fullName()}`)
-      .then(() => {
-        void window.showInformationMessage(`Coppied account 0x${activeAccount.address} to clipboard`)
-      })
+      void env.clipboard.writeText(`${activeAccount.fullName()}`)
+        .then(() => {
+          void window.showInformationMessage(`Coppied account 0x${activeAccount.address} to clipboard`)
+        })
     } else {
-      void window.showInformationMessage(`No active account, emulator has not been started.`)
+      void window.showInformationMessage('No active account, emulator has not been started.')
     }
   }
 }

--- a/extension/src/emulator/emulator-controller.ts
+++ b/extension/src/emulator/emulator-controller.ts
@@ -122,8 +122,6 @@ export class EmulatorController {
         .then(() => {
           void window.showInformationMessage(`Coppied account ${activeAccount.fullName()} to clipboard`)
         })
-    } else {
-      void window.showInformationMessage('No active account, emulator has not been started.')
     }
   }
 }

--- a/extension/src/emulator/emulator-controller.ts
+++ b/extension/src/emulator/emulator-controller.ts
@@ -9,7 +9,7 @@ import { AccountManager } from './tools/account-manager'
 import { LanguageServerAPI } from './server/language-server'
 import { Settings } from '../settings/settings'
 import { Account } from './account'
-import { window } from 'vscode'
+import { window, env } from 'vscode'
 
 export enum EmulatorState {
   Stopped = 0,
@@ -113,5 +113,17 @@ export class EmulatorController {
 
   getActiveAccount (): Account | null {
     return this.#accountManager.getActiveAccount()
+  }
+
+  copyActiveAccount (): void {
+    const activeAccount = this.#accountManager.getActiveAccount()
+    if (activeAccount !== null) {
+      env.clipboard.writeText(`${activeAccount.fullName()}`)
+      .then(() => {
+        void window.showInformationMessage(`Coppied account 0x${activeAccount.address} to clipboard`)
+      })
+    } else {
+      void window.showInformationMessage(`No active account, emulator has not been started.`)
+    }
   }
 }

--- a/extension/src/emulator/emulator-controller.ts
+++ b/extension/src/emulator/emulator-controller.ts
@@ -120,7 +120,7 @@ export class EmulatorController {
     if (activeAccount !== null) {
       void env.clipboard.writeText(`${activeAccount.fullName()}`)
         .then(() => {
-          void window.showInformationMessage(`Coppied account 0x${activeAccount.address} to clipboard`)
+          void window.showInformationMessage(`Coppied account ${activeAccount.fullName()} to clipboard`)
         })
     } else {
       void window.showInformationMessage('No active account, emulator has not been started.')

--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
 				"title": "Switch account"
 			},
 			{
+				"command": "cadence.copyActiveAccount",
+				"category": "Cadence",
+				"title": "Copy active account to clipboard"
+			},
+			{
 				"command": "cadence.checkDepencencies",
 				"category": "Cadence",
 				"title": "Check Dependencies"


### PR DESCRIPTION
Closes #22 

## Description

Added a command to copy the active account to clipboard.
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
