### PR TITLE
Add Sentry usage statistics

### DIFF
--- a/extension/src/main.ts
+++ b/extension/src/main.ts
@@ -8,7 +8,7 @@ export let ext: Extension
 
 // Called by VS Code when the extension starts up
 export async function activate (ctx: ExtensionContext): Promise<Extension> {
-  Telemetry.initialize()
+  await Telemetry.initialize(ctx)
 
   // Initialize the extension
   Telemetry.withTelemetry(() => {

--- a/extension/src/telemetry/sentry-wrapper.ts
+++ b/extension/src/telemetry/sentry-wrapper.ts
@@ -18,6 +18,10 @@ export function sentryInit (activate: boolean): void {
   })
 }
 
+export function setUser (id: string): void {
+  Sentry.setUser({ id: id })
+}
+
 export async function sentryClose (): Promise<void> {
   if (!sentryActivated) return
   void await Sentry.close()
@@ -30,4 +34,9 @@ export function captureException (exception: any, captureContent?: Type.CaptureC
   })
   Sentry.captureException(exception, captureContent)
   transaction.finish()
+}
+
+export function captureStatistics (message: string): void {
+  if (!sentryActivated) return
+  Sentry.captureMessage(message, 'info')
 }

--- a/extension/src/telemetry/telemetry.ts
+++ b/extension/src/telemetry/telemetry.ts
@@ -1,14 +1,41 @@
 /* Telemetry functions */
 import * as sentry from './sentry-wrapper'
-import { env } from 'vscode'
+import { env, ExtensionContext } from 'vscode'
+import { DEBUG_ACTIVE } from '../utils/debug'
+import * as uuid from 'uuid'
+import * as pkg from '../../../package.json'
+
+async function getUID (ctx: ExtensionContext): Promise<string> {
+  const uid: string | undefined = ctx.globalState.get<string>('uid')
+  if (uid === undefined) {
+    // Generate new uid and add it to global state
+    const uidGen: string = uuid.v4()
+    await ctx.globalState.update('uid', uidGen)
+    return uidGen
+  }
+  return uid
+}
 
 // Called in main to setup telemetry
-export function initialize (): void {
+export async function initialize (ctx: ExtensionContext): Promise<void> {
   // Check if user is allowing telemetry for vscode globally
-  const activate: boolean = env.isTelemetryEnabled
+  const activate: boolean = env.isTelemetryEnabled && !DEBUG_ACTIVE
 
   // Initialize Sentry
-  sentry.sentryInit(activate)
+  await sentry.sentryInit(activate)
+
+  // Get unique UID
+  const uid = await getUID(ctx)
+
+  // Set uid for Sentry
+  sentry.setUser(uid)
+
+  // Send initial statistics
+  sendVersionStatistics()
+}
+
+function sendVersionStatistics (): void {
+  sentry.captureStatistics('Activated Extension - version: ' + pkg.version)
 }
 
 // Called in main to deactivate telemetry

--- a/extension/src/utils/debug.ts
+++ b/extension/src/utils/debug.ts
@@ -1,4 +1,4 @@
-const DEBUG_ACTIVE: boolean = true
+export const DEBUG_ACTIVE: boolean = true
 
 export function DEBUG_LOG (str: string): void {
   if (DEBUG_ACTIVE) {

--- a/extension/src/utils/debug.ts
+++ b/extension/src/utils/debug.ts
@@ -1,4 +1,4 @@
-export const DEBUG_ACTIVE: boolean = true
+export const DEBUG_ACTIVE: boolean = false
 
 export function DEBUG_LOG (str: string): void {
   if (DEBUG_ACTIVE) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@sentry/node": "^7.6.0",
 				"ansi-regex": "^6.0.1",
 				"mocha": "^10.0.0",
+				"uuid": "^8.3.2",
 				"vsce": "^2.9.1",
 				"vscode-languageclient": "^8.0.1"
 			},
@@ -432,6 +433,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/@cypress/request/node_modules/uuid": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"dev": true,
+			"bin": {
+				"uuid": "bin/uuid"
 			}
 		},
 		"node_modules/@cypress/xvfb": {
@@ -8855,13 +8866,11 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"node_modules/uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-			"dev": true,
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache": {
@@ -9563,6 +9572,12 @@
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 					"dev": true
 				}
 			}
@@ -15863,10 +15878,9 @@
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-			"dev": true
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@sentry/node": "^7.6.0",
 				"ansi-regex": "^6.0.1",
 				"mocha": "^10.0.0",
+				"uuid": "^8.3.2",
 				"vsce": "^2.9.1",
 				"vscode-languageclient": "^8.0.1"
 			},
@@ -8871,6 +8872,14 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
 		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -15880,6 +15889,11 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,13 @@
 				"@sentry/node": "^7.6.0",
 				"ansi-regex": "^6.0.1",
 				"mocha": "^10.0.0",
-				"uuid": "^8.3.2",
 				"vsce": "^2.9.1",
 				"vscode-languageclient": "^8.0.1"
 			},
 			"devDependencies": {
 				"@types/glob": "^7.1.4",
 				"@types/node": "^10.12.21",
+				"@types/uuid": "8.3.4",
 				"@types/vscode": "^1.65.0",
 				"@vscode/test-electron": "^2.1.5",
 				"cypress": "^8.3.0",
@@ -766,6 +766,12 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
 			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+			"dev": true
+		},
+		"node_modules/@types/uuid": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
 		},
 		"node_modules/@types/vscode": {
@@ -8865,14 +8871,6 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
-		"node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/v8-compile-cache": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9840,6 +9838,12 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
 			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+			"dev": true
+		},
+		"@types/uuid": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+			"integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
 			"dev": true
 		},
 		"@types/vscode": {
@@ -15876,11 +15880,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
 	"devDependencies": {
 		"@types/glob": "^7.1.4",
 		"@types/node": "^10.12.21",
+		"@types/uuid": "8.3.4",
 		"@types/vscode": "^1.65.0",
 		"@vscode/test-electron": "^2.1.5",
 		"cypress": "^8.3.0",
@@ -183,7 +184,6 @@
 		"@sentry/node": "^7.6.0",
 		"ansi-regex": "^6.0.1",
 		"mocha": "^10.0.0",
-		"uuid": "^8.3.2",
 		"vsce": "^2.9.1",
 		"vscode-languageclient": "^8.0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
 		"ansi-regex": "^6.0.1",
 		"mocha": "^10.0.0",
 		"vsce": "^2.9.1",
+		"uuid": "^8.3.2",
 		"vscode-languageclient": "^8.0.1"
 	},
 	"__metadata": {

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
 		"@sentry/node": "^7.6.0",
 		"ansi-regex": "^6.0.1",
 		"mocha": "^10.0.0",
+		"uuid": "^8.3.2",
 		"vsce": "^2.9.1",
 		"vscode-languageclient": "^8.0.1"
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"module": "commonjs",
 		"target": "es6",
 		"outDir": "out",
+		"resolveJsonModule": true,
 		"lib": [
 			"es6", "dom"
 		],


### PR DESCRIPTION
Closes #144 

## Description

- Added sentry information to track activations and corresponding version numbers.
- Generate and store unique user ids for Sentry.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
