### PR TITLE
Update e2e tests for v1.0.0 release

### DIFF
--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -8,7 +8,7 @@ import * as semver from 'semver'
 
 // Command to check flow-cli
 const CHECK_FLOW_CLI_CMD = 'flow version'
-const COMPATIBLE_FLOW_CLI_VERSIONS = '0.39.2 || >=0.39.2'
+const COMPATIBLE_FLOW_CLI_VERSIONS = '>=0.39.2'
 
 // Flow CLI with homebrew
 const CHECK_HOMEBREW_CMD = 'brew help help' // Run this to check if brew is executable

--- a/extension/test/e2e/2-deploy-contract.test.ts
+++ b/extension/test/e2e/2-deploy-contract.test.ts
@@ -14,8 +14,7 @@ describe('User Story test: Deploy Contract', () => {
     cy.contains('Deploy contract FooContract to Alice')
       .click({ force: true })
 
-    cy.contains('Deploying contract FooContract to account f8d6e0586b0a20c7')
-      .should('be.visible')
+    cy.contains('Contract FooContract has been deployed to account Alice')
 
     switchAccount(cy, Accounts.Alice, Accounts.Bob)
 
@@ -28,7 +27,6 @@ describe('User Story test: Deploy Contract', () => {
     cy.contains('Deploy contract FooContract to Bob')
       .click({ force: true })
 
-    cy.contains('Deploying contract FooContract to account 179b6b1cb6755e31')
-      .should('be.visible')
+    cy.contains('Contract FooContract has been deployed to account Bob')
   })
 })

--- a/extension/test/e2e/4-send-transaction.test.ts
+++ b/extension/test/e2e/4-send-transaction.test.ts
@@ -12,6 +12,6 @@ describe('User Story test: Send Transaction', () => {
     openFile(cy, 'Tx.cdc')
 
     cy.contains('Send signed by Alice').click({ force: true })
-    cy.contains('Transaction status: SEALED')
+    cy.contains('Transaction SEALED with ID')
   })
 })

--- a/extension/test/e2e/cypress-helpers.ts
+++ b/extension/test/e2e/cypress-helpers.ts
@@ -18,7 +18,7 @@ export function initTest (cy: Cypress.cy): void {
 
 export function initExtension (cy: Cypress.cy): void {
   openFile(cy, 'NonFungibleToken.cdc') // default file to trigger start extension
-  cy.contains('Cadence language server started', { timeout: 100000 })
+  cy.contains('Flow Emulator Connected', { timeout: 100000 })
 }
 
 export function openFile (cy: Cypress.cy, name: string): void {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"lint": "ts-standard",
 		"lint-fix": "ts-standard --fix",
 		"docker-install-extension": "docker exec vscode code-server --install-extension /source/cadence.vsix",
-		"docker-install-flow-cli": "docker exec vscode sh -ci \"$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)\" -- v0.39.2",
+		"docker-install-flow-cli": "docker exec vscode sh -ci \"$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)\"",
 		"vscode-start": "docker-compose up -d && npm run docker-install-extension && npm run docker-install-flow-cli",
 		"vscode-stop": "docker-compose down",
 		"cypress": "./node_modules/.bin/cypress run",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"lint": "ts-standard",
 		"lint-fix": "ts-standard --fix",
 		"docker-install-extension": "docker exec vscode code-server --install-extension /source/cadence.vsix",
-		"docker-install-flow-cli": "docker exec vscode sh -ci \"$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)\"",
+		"docker-install-flow-cli": "docker exec vscode sh -ci \"$(curl -fsSL https://storage.googleapis.com/flow-cli/install.sh)\" -- v0.39.2",
 		"vscode-start": "docker-compose up -d && npm run docker-install-extension && npm run docker-install-flow-cli",
 		"vscode-stop": "docker-compose down",
 		"cypress": "./node_modules/.bin/cypress run",


### PR DESCRIPTION
Closes #156 

## Description

- Updated e2e-tests to reflect new output strings from LS
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
