### PR TITLE
Ignore syntax errors in Sentry

### DIFF
--- a/extension/src/telemetry/sentry-wrapper.ts
+++ b/extension/src/telemetry/sentry-wrapper.ts
@@ -16,7 +16,11 @@ export async function sentryInit (activate: boolean, uid: string, version: strin
   Sentry.init({
     dsn: SENTRY_DSN,
     tracesSampleRate: 1.0,
-    attachStacktrace: true
+    attachStacktrace: true,
+    ignoreErrors: [
+      'SyntaxError', // Caused by Language Server on invalid syntax
+      'No valid config path' // User doesn't have a valid flow.json file path
+    ]
   })
 
   // Set user information


### PR DESCRIPTION
Closes #160 

## Description

Added an ignore list to sentry initialization in order to ignore:
- Syntax Errors from the language server
- No valid config path error caused by no flow.json file

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
