### PR TITLE
Fix path to language configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 				"extensions": [
 					".cdc"
 				],
-				"configuration": "./language/language-configuration.json"
+				"configuration": "./extension/language/language-configuration.json"
 			}
 		],
 		"grammars": [


### PR DESCRIPTION
Fixes #187
Fixes #181

## Description

The path to the language configuration was wrong. It seems like the directory structure changes and this was missed. 

Would be nice if VS Code could report an error if the specified path does not exist instead of silently ignoring it.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
