### PR TITLE
Reload flow configuration when changed

### DIFF
--- a/extension/src/emulator/local/config.ts
+++ b/extension/src/emulator/local/config.ts
@@ -79,9 +79,18 @@ async function readLocalConfig (): Promise<string> {
 }
 
 export function watchFlowConfigChanges(changedEvent: () => {}) {
+  let updateDelay: any = null
   workspace.onDidChangeTextDocument(e => {
-    if (configPath !== undefined && e.document.fileName == configPath) {
-      changedEvent()
+    if (configPath == undefined || e.document.fileName != configPath) {
+      return
+    }
+
+    // request deduplication - we do this to avoid spamming requests in a short time period but rather aggragete into one
+    if (updateDelay == null) {
+      updateDelay = setTimeout(() => {
+        changedEvent()
+        updateDelay = null
+      }, 500)
     }
   })
 }

--- a/extension/src/emulator/local/config.ts
+++ b/extension/src/emulator/local/config.ts
@@ -78,13 +78,12 @@ async function readLocalConfig (): Promise<string> {
   return configFilePath
 }
 
-export function watchFlowConfigChanges(changedEvent: () => {}) {
-  let updateDelay: any = null
-  workspace.onDidChangeTextDocument(e => {
-    if (configPath == undefined || e.document.fileName != configPath) {
-      return
-    }
+export async function watchFlowConfigChanges(changedEvent: () => {}) {
+  const path = await getConfigPath()
+  const configWatcher = workspace.createFileSystemWatcher(path)
 
+  let updateDelay: any = null
+  configWatcher.onDidChange(e => {
     // request deduplication - we do this to avoid spamming requests in a short time period but rather aggragete into one
     if (updateDelay == null) {
       updateDelay = setTimeout(() => {

--- a/extension/src/emulator/local/config.ts
+++ b/extension/src/emulator/local/config.ts
@@ -78,7 +78,7 @@ async function readLocalConfig (): Promise<string> {
   return configFilePath
 }
 
-export async function watchFlowConfigChanges(changedEvent: () => {}) {
+export async function watchFlowConfigChanges (changedEvent: () => {}) {
   const path = await getConfigPath()
   const configWatcher = workspace.createFileSystemWatcher(path)
 

--- a/extension/src/emulator/local/config.ts
+++ b/extension/src/emulator/local/config.ts
@@ -78,7 +78,7 @@ async function readLocalConfig (): Promise<string> {
   return configFilePath
 }
 
-export async function watchFlowConfigChanges (changedEvent: () => {}) {
+export async function watchFlowConfigChanges (changedEvent: () => {}): Promise<void> {
   const path = await getConfigPath()
   const configWatcher = workspace.createFileSystemWatcher(path)
 

--- a/extension/src/emulator/local/config.ts
+++ b/extension/src/emulator/local/config.ts
@@ -78,6 +78,14 @@ async function readLocalConfig (): Promise<string> {
   return configFilePath
 }
 
+export function watchFlowConfigChanges(changedEvent: () => {}) {
+  workspace.onDidChangeTextDocument(e => {
+    if (configPath !== undefined && e.document.fileName == configPath) {
+      changedEvent()
+    }
+  })
+}
+
 // Called when configuration is changed
 function handleConfigChanges (): void {
   workspace.onDidChangeConfiguration((e) => {

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -5,7 +5,7 @@ import { ext } from '../../main'
 import * as Config from '../local/config'
 import { Settings } from '../../settings/settings'
 import * as response from './responses'
-import {watch} from "fs/promises";
+import { watch } from 'fs/promises'
 
 // Identities for commands handled by the Language server
 const CREATE_ACCOUNT_SERVER = 'cadence.server.flow.createAccount'
@@ -103,7 +103,7 @@ export class LanguageServerAPI {
 
   // Watch and reload flow configuration when changed.
   watchFlowConfiguration () {
-    Config.watchFlowConfigChanges(() => this.#sendRequest(RELOAD_CONFIGURATION))
+    Config.watchFlowConfigChanges(async () => await this.#sendRequest(RELOAD_CONFIGURATION))
   }
 
   // Sends a request to create a new account. Returns the address of the new

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -5,7 +5,6 @@ import { ext } from '../../main'
 import * as Config from '../local/config'
 import { Settings } from '../../settings/settings'
 import * as response from './responses'
-import { watch } from 'fs/promises'
 
 // Identities for commands handled by the Language server
 const CREATE_ACCOUNT_SERVER = 'cadence.server.flow.createAccount'
@@ -102,8 +101,8 @@ export class LanguageServerAPI {
   }
 
   // Watch and reload flow configuration when changed.
-  watchFlowConfiguration () {
-    Config.watchFlowConfigChanges(async () => await this.#sendRequest(RELOAD_CONFIGURATION))
+  watchFlowConfiguration (): void {
+    void Config.watchFlowConfigChanges(async () => await this.#sendRequest(RELOAD_CONFIGURATION))
   }
 
   // Sends a request to create a new account. Returns the address of the new

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -69,10 +69,6 @@ export class Extension {
     refreshCodeLenses()
   }
 
-  watchFileChanges (): void {
-
-  }
-
   checkDependencies (): void {
     this.#dependencyInstaller.checkDependencies()
   }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -69,6 +69,10 @@ export class Extension {
     refreshCodeLenses()
   }
 
+  watchFileChanges (): void {
+
+  }
+
   checkDependencies (): void {
     this.#dependencyInstaller.checkDependencies()
   }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/57

## Description
Reload configuration when changed so the LS can reload.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
