### PR TITLE
Enable LS to wait for flow-cli update

### DIFF
--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -5,7 +5,7 @@ import { ext } from '../../main'
 import * as Config from '../local/config'
 import { Settings } from '../../settings/settings'
 import * as response from './responses'
-import sleepSynchronously from 'sleep-synchronously';
+import sleepSynchronously from 'sleep-synchronously'
 
 // Identities for commands handled by the Language server
 const CREATE_ACCOUNT_SERVER = 'cadence.server.flow.createAccount'
@@ -68,8 +68,7 @@ export class LanguageServerAPI {
       if (this.#initializedClient && !this.running) {
         void window.showErrorMessage('Cadence language server stopped')
         sleepSynchronously(1000 * 5) // Wait enable flow-cli update
-      }
-      else if (this.running) {
+      } else if (this.running) {
         void window.showInformationMessage('Cadence language server started')
       }
       void ext.emulatorStateChanged()

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -5,6 +5,7 @@ import { ext } from '../../main'
 import * as Config from '../local/config'
 import { Settings } from '../../settings/settings'
 import * as response from './responses'
+import sleepSynchronously from 'sleep-synchronously';
 
 // Identities for commands handled by the Language server
 const CREATE_ACCOUNT_SERVER = 'cadence.server.flow.createAccount'
@@ -66,10 +67,10 @@ export class LanguageServerAPI {
       this.running = e.newState === State.Running
       if (this.#initializedClient && !this.running) {
         void window.showErrorMessage('Cadence language server stopped')
-        // TODO: Wait before restarting
+        sleepSynchronously(1000 * 5) // Wait enable flow-cli update
       }
-      if (this.#initializedClient && this.running) {
-        void window.showErrorMessage('Cadence language server started')
+      else if (this.running) {
+        void window.showInformationMessage('Cadence language server started')
       }
       void ext.emulatorStateChanged()
     })

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -66,6 +66,10 @@ export class LanguageServerAPI {
       this.running = e.newState === State.Running
       if (this.#initializedClient && !this.running) {
         void window.showErrorMessage('Cadence language server stopped')
+        // TODO: Wait before restarting
+      }
+      if (this.#initializedClient && this.running) {
+        void window.showErrorMessage('Cadence language server started')
       }
       void ext.emulatorStateChanged()
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"mixpanel": "^0.17.0",
 				"node-fetch": "^3.3.0",
 				"os-name": "^5.0.1",
+				"sleep-synchronously": "^2.0.0",
 				"uuid": "^9.0.0",
 				"vsce": "^2.15.0",
 				"vscode-languageclient": "^8.0.2"
@@ -8319,6 +8320,17 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/sleep-synchronously": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sleep-synchronously/-/sleep-synchronously-2.0.0.tgz",
+			"integrity": "sha512-jUT5wbEyeo4P5FkZJhZD8HiMcq+gkg/8GPxG3uuxrtfUuKOzFL5k7AXD/xcZOYHmsTSzvKLnoE8VpI883vzdTQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/slice-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -15840,6 +15852,11 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
+		},
+		"sleep-synchronously": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/sleep-synchronously/-/sleep-synchronously-2.0.0.tgz",
+			"integrity": "sha512-jUT5wbEyeo4P5FkZJhZD8HiMcq+gkg/8GPxG3uuxrtfUuKOzFL5k7AXD/xcZOYHmsTSzvKLnoE8VpI883vzdTQ=="
 		},
 		"slice-ansi": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
 		"mixpanel": "^0.17.0",
 		"node-fetch": "^3.3.0",
 		"os-name": "^5.0.1",
+		"sleep-synchronously": "^2.0.0",
 		"uuid": "^9.0.0",
 		"vsce": "^2.15.0",
 		"vscode-languageclient": "^8.0.2"


### PR DESCRIPTION
Closes #215 

## Description

Added a delay on restarting the language server to enable flow.exe to be updated on Windows when the running flow.exe process is killed.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
