### PR TITLE
Add missing configuration for access check mode

### DIFF
--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -43,6 +43,7 @@ export class LanguageServerAPI {
     this.#initializedClient = false
     const configPath = await Config.getConfigPath()
     const numberOfAccounts = Settings.getWorkspaceSettings().numAccounts
+    const accessCheckMode = Settings.getWorkspaceSettings().accessCheckMode
 
     this.client = new LanguageClient(
       'cadence',
@@ -58,7 +59,8 @@ export class LanguageServerAPI {
         },
         initializationOptions: {
           configPath: configPath,
-          numberOfAccounts: `${numberOfAccounts}`
+          numberOfAccounts: `${numberOfAccounts}`,
+          accessCheckMode: accessCheckMode
         }
       }
     )


### PR DESCRIPTION
Closes #234 

## Description
Adds missing configuration value to initialization for accessCheckMode.
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
