### PR TITLE
Update required flow-cli version

### DIFF
--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -10,7 +10,7 @@ import fetch from 'node-fetch'
 
 // Command to check flow-cli
 const CHECK_FLOW_CLI_CMD = 'flow version'
-const COMPATIBLE_FLOW_CLI_VERSIONS = '>=0.43.2'
+const COMPATIBLE_FLOW_CLI_VERSIONS = '>=0.44.0'
 
 // Flow CLI with homebrew
 const CHECK_HOMEBREW_CMD = 'brew help help' // Run this to check if brew is executable

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Cadence",
 	"publisher": "onflow",
 	"description": "This extension integrates Cadence, the resource-oriented smart contract programming language of Flow, into Visual Studio Code.",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/onflow/vscode-cadence.git"


### PR DESCRIPTION
Closes #233 #239 

## Description
- Updates flow-cli required minimum version to v0.44.0 to enable LS updates
- Updated extension version to v1.0.7
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
