### PR TITLE
Verify emulator startup location

### DIFF
--- a/extension/src/emulator/local/emulatorScanner.ts
+++ b/extension/src/emulator/local/emulatorScanner.ts
@@ -1,0 +1,57 @@
+import portScanner = require('portscanner-sync')
+import awaitToJs = require('await-to-js')
+import find = require('find-process');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec)
+
+export async function emulatorExists (): Promise<boolean> {
+  const defaultHost = '127.0.0.1'
+  const defaultPort = 3569
+  const [err, status] = await awaitToJs.to(portScanner.checkPortStatus(defaultPort, defaultHost))
+  if (err != null) {
+    console.error(err)
+    return false
+  }
+
+  return status === 'open'
+}
+
+// Warn user if running emulator in different directory from flow.json
+export async function checkEmulatorLocation (flowJsonDir: string): Promise<void> {
+  let emulatorDir = await emulatorRunPath()
+
+  console.log("flow.json dir: ", flowJsonDir)
+  console.log("flow emulator dir: ", emulatorDir)
+
+  //TODO: Make sure flowJsonDir doesn't have /flow.json at the end of it
+  if (emulatorDir !== flowJsonDir) {
+    // TODO: Warn user that the emulator they're running is not running from the
+    // TODO: same directory as their flow.json
+    //window.showWarningMessage(`Emulator is running from: ${emulatorPath}`)
+  }
+}
+
+
+// Tries to return the path where flow emulator was run from
+export async function emulatorRunPath (): Promise<string | undefined> {
+  // TODO: Find path on Windows as well!!
+
+
+  try {
+    let emuProccessInfo = (await find('name', 'flow emulator'))
+
+    // TODO: Check if empty
+    if (!emuProccessInfo) {
+      return undefined
+    }
+
+    const pid = emuProccessInfo[0].pid
+    const cwdIndex = 8 // Dir index in lsof command
+    let output = await exec(`lsof -p ${pid} | grep cwd`)
+    let emulatorPath: string = output.stdout.trim().split(/\s+/)[cwdIndex]
+
+    return emulatorPath
+  } catch (err) {
+    return undefined
+  }
+}

--- a/extension/src/emulator/local/emulatorScanner.ts
+++ b/extension/src/emulator/local/emulatorScanner.ts
@@ -61,11 +61,9 @@ export async function validEmulatorLocation (): Promise<boolean> {
 export async function emulatorRunPath (): Promise<string | undefined> {
   try {
     const emuProccessInfo = (await find('name', 'flow emulator'))
-    const pid = emuProccessInfo[0].pid
+    const output = await promisifyExec(`lsof -p ${emuProccessInfo[0].pid} | grep cwd`)
     const cwdIndex = 8 // Runpath dir index in lsof command
-    const output = await promisifyExec(`lsof -p ${pid} | grep cwd`)
     const emulatorPath: string = output.stdout.trim().split(/\s+/)[cwdIndex]
-
     return emulatorPath
   } catch (err) {
     return undefined

--- a/extension/src/emulator/local/emulatorScanner.ts
+++ b/extension/src/emulator/local/emulatorScanner.ts
@@ -4,6 +4,10 @@ import find = require('find-process');
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec)
 import { window } from 'vscode'
+import * as Config from './config'
+import os = require("os")
+
+let showLocationWarning = true
 
 export async function emulatorExists (): Promise<boolean> {
   const defaultHost = '127.0.0.1'
@@ -15,48 +19,78 @@ export async function emulatorExists (): Promise<boolean> {
   }
 
   if (status !== 'open') {
+    showLocationWarning = true
     return false
   }
 
-  // TODO: Only consider an emulator as valid if it's in the same dir as flow.json
-  // TODO: Otherwise the LS will crash anyways, so we shouldn't connect to it and 
-  // TODO: give a warning instead
+  // Only connect to emulator if running from same dir as flow.json or else LS will crash
   if (!await validEmulatorLocation()) {
-    window.showWarningMessage(`Emulator detected running in a different directory than your flow.json 
-    config. To connect an emulator, please run 'flow emulator' in the same directory as your flow.json`)
+    if (showLocationWarning) {
+      window.showWarningMessage(`Emulator detected running in a different directory than your flow.json 
+      config. To connect an emulator, please run 'flow emulator' in the same directory as your flow.json`)
+      showLocationWarning = false // Avoid spamming the location warning
+    }
+    return false
   }
 
+  showLocationWarning = true
 
-
-  return status === 'open'
+  return true
 }
 
-// Warn user if running emulator in different directory from flow.json
-async function validEmulatorLocation (configPath: string): Promise<boolean> {
+async function validEmulatorLocation (): Promise<boolean> {
+  const configPath = await Config.getConfigPath()
   let flowJsonDir = configPath.substring(0, configPath.lastIndexOf('/'))
-  let emulatorDir = await emulatorRunPath()
+  let emulatorDir: string | undefined = undefined
+
+  switch (os.platform()) {
+    case 'darwin':
+    case 'linux':
+      emulatorDir = await emulatorRunPath()
+    case 'win32':
+      emulatorDir = await emulatorRunPathWindows()
+    default:
+      console.log('Cannot find emulator runpath on ', os.platform())
+  }
+
   return emulatorDir === flowJsonDir
 }
 
-
-// Tries to return the path where flow emulator was run from
 export async function emulatorRunPath (): Promise<string | undefined> {
-  // TODO: Find path on Windows as well!!
-
-
   try {
     let emuProccessInfo = (await find('name', 'flow emulator'))
-
-    // TODO: Check if empty
     if (!emuProccessInfo) {
+      console.log('No running flow emulator process')
       return undefined
     }
 
+    const pid = emuProccessInfo[0].pid
+    const cwdIndex = 8 // Runpath dir index in lsof command
+    let output = await exec(`lsof -p ${pid} | grep cwd`)
+    let emulatorPath: string = output.stdout.trim().split(/\s+/)[cwdIndex]
+
+    return emulatorPath
+  } catch (err) {
+    return undefined
+  }
+}
+
+export async function emulatorRunPathWindows (): Promise<string | undefined> {
+  // TODO: Find path on Windows as well!!
+
+  try {
+    let emuProccessInfo = (await find('name', 'flow emulator'))
+    if (!emuProccessInfo) {
+      console.log('No running flow emulator process')
+      return undefined
+    }
+    
     const pid = emuProccessInfo[0].pid
     const cwdIndex = 8 // Dir index in lsof command
     let output = await exec(`lsof -p ${pid} | grep cwd`)
     let emulatorPath: string = output.stdout.trim().split(/\s+/)[cwdIndex]
 
+    console.log('Flow emulator with pid: ', pid, ' is running from: ', emulatorPath)
     return emulatorPath
   } catch (err) {
     return undefined

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -8,7 +8,7 @@ import * as response from './responses'
 import sleepSynchronously from 'sleep-synchronously'
 import { Mutex } from 'async-mutex'
 import { exec } from 'child_process'
-import { emulatorExists } from '../local/emulatorScanner'
+import { emulatorExists, validEmulatorLocation } from '../local/emulatorScanner'
 
 // Identities for commands handled by the Language server
 const CREATE_ACCOUNT_SERVER = 'cadence.server.flow.createAccount'

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -57,6 +57,7 @@ export class LanguageServerAPI {
         }
 
         this.#emulatorConnected = emulatorFound
+        void this.checkEmulatorLocation()
         this.#clientLock.release()
 
         void this.restart(emulatorFound)
@@ -74,6 +75,12 @@ export class LanguageServerAPI {
     }
 
     return status === 'open'
+  }
+
+  async checkEmulatorLocation (): Promise<void> {
+    // TODO: Detect if emulator was run in the same location as the current flow.json
+    // If not, warn user to run emulator from their project directory containing flow.json
+    return false
   }
 
   async startClient (enableFlow?: boolean): Promise<void> {

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -8,7 +8,6 @@ import * as response from './responses'
 import sleepSynchronously from 'sleep-synchronously'
 import { Mutex } from 'async-mutex'
 import { exec } from 'child_process'
-import { checkEmulatorLocation } from '../local/emulatorScanner'
 import { emulatorExists } from '../local/emulatorScanner'
 
 // Identities for commands handled by the Language server
@@ -76,8 +75,6 @@ export class LanguageServerAPI {
     if (enableFlow === undefined) {
       enableFlow = await emulatorExists()
       this.#emulatorConnected = enableFlow
-    } else if (enableFlow) {
-      checkEmulatorLocation(configPath)
     }
 
     if (this.flowCommand !== 'flow') {

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -8,7 +8,7 @@ import * as response from './responses'
 import sleepSynchronously from 'sleep-synchronously'
 import { Mutex } from 'async-mutex'
 import { exec } from 'child_process'
-import { emulatorExists, validEmulatorLocation } from '../local/emulatorScanner'
+import { emulatorExists } from '../local/emulatorScanner'
 
 // Identities for commands handled by the Language server
 const CREATE_ACCOUNT_SERVER = 'cadence.server.flow.createAccount'

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"ansi-regex": "^6.0.1",
 				"async-lock": "^1.4.0",
 				"async-mutex": "^0.4.0",
+				"find-process": "^1.4.7",
 				"mixpanel": "^0.17.0",
 				"node-fetch": "^3.3.0",
 				"os-name": "^5.0.1",
@@ -4557,6 +4558,91 @@
 			},
 			"funding": {
 				"url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+			}
+		},
+		"node_modules/find-process": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+			"integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"commander": "^5.1.0",
+				"debug": "^4.1.1"
+			},
+			"bin": {
+				"find-process": "bin/find-process.js"
+			}
+		},
+		"node_modules/find-process/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/find-process/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/find-process/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/find-process/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"node_modules/find-process/node_modules/commander": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/find-process/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/find-process/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/find-up": {
@@ -13637,6 +13723,66 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
 				"pkg-dir": "^4.1.0"
+			}
+		},
+		"find-process": {
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/find-process/-/find-process-1.4.7.tgz",
+			"integrity": "sha512-/U4CYp1214Xrp3u3Fqr9yNynUrr5Le4y0SsJh2lMDDSbpwYSz3M2SMWQC+wqcx79cN8PQtHQIL8KnuY9M66fdg==",
+			"requires": {
+				"chalk": "^4.0.0",
+				"commander": "^5.1.0",
+				"debug": "^4.1.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"commander": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+					"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"find-up": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"async-lock": "^1.4.0",
 				"async-mutex": "^0.4.0",
 				"find-process": "^1.4.7",
+				"lsof": "^0.1.0",
 				"mixpanel": "^0.17.0",
 				"node-fetch": "^3.3.0",
 				"os-name": "^5.0.1",
@@ -7020,6 +7021,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/lsof": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lsof/-/lsof-0.1.0.tgz",
+			"integrity": "sha512-RlNW3s4gQ0CIlDM3jwfx/Ogdwpa8PHySyd5FnKKXfi2NPXEjqgwONyA0y9ax33ur1G+K+f192zzKNQljupSgNA==",
+			"deprecated": "No longer maintained",
+			"engines": {
+				"node": ">= 0.2.0"
 			}
 		},
 		"node_modules/macos-release": {
@@ -15504,6 +15514,11 @@
 			"requires": {
 				"yallist": "^4.0.0"
 			}
+		},
+		"lsof": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lsof/-/lsof-0.1.0.tgz",
+			"integrity": "sha512-RlNW3s4gQ0CIlDM3jwfx/Ogdwpa8PHySyd5FnKKXfi2NPXEjqgwONyA0y9ax33ur1G+K+f192zzKNQljupSgNA=="
 		},
 		"macos-release": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
 		"ansi-regex": "^6.0.1",
 		"async-lock": "^1.4.0",
 		"async-mutex": "^0.4.0",
+		"find-process": "^1.4.7",
 		"mixpanel": "^0.17.0",
 		"node-fetch": "^3.3.0",
 		"os-name": "^5.0.1",


### PR DESCRIPTION
Closes #244 

## Description
The extension will now verify the location where flow emulator is running. If an emulator is not running in the same directory as a user's flow.json, a warning will be displayed and the extension will not connect to the emulator.

- Only supported on Mac/ Linux systems
- Unfortunately there's no nice way to support this feature on Windows, the extension will connect to any emulator which causes issues when run in the wrong location

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
