### PR TITLE
Update Cadence language server link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Use your best judgment, and feel free to propose changes to this document in a p
 # Developing the Extension
 
 Note that most editing features (type checking, code completion, etc.) are implemented
-in the [Cadence Language Server](https://github.com/onflow/cadence/tree/master/languageserver).
+in the [Cadence Language Server](https://github.com/onflow/cadence-tools/tree/master/languageserver).
 
 ## Pre-requisites
 


### PR DESCRIPTION
Since the language server has been removed from the [onflow/cadence](https://github.com/onflow/cadence) repository ([this PR](https://github.com/onflow/cadence/commit/525d622acf2b19068373522018bad1ebb5e07e83)), we need to update the link in [CONTRIBUTING.md](https://github.com/onflow/vscode-cadence/blob/7d8a7aa39957d484171cfcb726056fdba94588a8/CONTRIBUTING.md) to the current one.

The language server codebase now exists in [onflow/cadence-tools](https://github.com/onflow/cadence-tools).