### PR TITLE
Make commands async so their execution may be awaited

### DIFF
--- a/extension/src/emulator/emulator-controller.ts
+++ b/extension/src/emulator/emulator-controller.ts
@@ -66,8 +66,8 @@ export class EmulatorController {
     }
   }
 
-  restartServer (): void {
-    void this.api.reset()
+  async restartServer (): Promise<void> {
+    await this.api.reset()
     void window.showInformationMessage('Restarted language server')
   }
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -79,7 +79,7 @@ export class Extension {
     await this.#dependencyInstaller.installMissing()
   }
 
-  executeCommand (command: string): boolean {
-    return this.#commands.executeCommand(command)
+  async executeCommand (command: string): Promise<boolean> {
+    return await this.#commands.executeCommand(command)
   }
 }

--- a/extension/src/telemetry/telemetry.ts
+++ b/extension/src/telemetry/telemetry.ts
@@ -55,9 +55,20 @@ function sendActivationStatistics (): void {
 }
 
 // Wrap a function call with telemetry
-export function withTelemetry (callback: (...args: any[]) => any): void {
+export function withTelemetry<R> (callback: () => R): R {
   try {
-    callback()
+    const returnValue = callback()
+    if (returnValue instanceof Promise) {
+      return returnValue.then((value) => {
+        return value
+      }).catch((err) => {
+        sentry.captureException(err)
+        mixpanel.captureException(err)
+        throw err
+      }) as R
+    } else {
+      return returnValue
+    }
   } catch (err) {
     sentry.captureException(err)
     mixpanel.captureException(err)

--- a/extension/test/integration/3 - commands.test.ts
+++ b/extension/test/integration/3 - commands.test.ts
@@ -7,11 +7,8 @@ import * as assert from 'assert'
 import { ext, testActivate } from '../../src/main'
 import { closeTerminalEmulator, startTerminalEmulator } from './terminal-emulator'
 import * as commands from '../../src/commands/command-constants'
-import { delay } from '..'
 import { filter, firstValueFrom } from 'rxjs'
 import { EmulatorState } from '../../src/emulator/server/language-server'
-
-const executionDelay = 5
 
 suite('Extension Commands', () => {
   let settings: Settings
@@ -41,22 +38,19 @@ suite('Extension Commands', () => {
 
   test('Command: Create Account', async () => {
     await startTerminalEmulator(waitForEmulatorActive, waitForEmulatorClosed)
-    assert.strictEqual(ext?.executeCommand(commands.CREATE_ACCOUNT), true)
-    await delay(executionDelay) // wait for command execution
+    assert.strictEqual(await ext?.executeCommand(commands.CREATE_ACCOUNT), true)
     const activeAccount = await ext?.getActiveAccount()
     assert.strictEqual(activeAccount?.name, 'Eve')
   }).timeout(MaxTimeout)
 
   test('Command: Restart Language Server', async () => {
     await startTerminalEmulator(waitForEmulatorActive, waitForEmulatorClosed)
-    assert.strictEqual(ext?.executeCommand(commands.RESTART_SERVER), true)
-    await delay(executionDelay)
+    assert.strictEqual(await ext?.executeCommand(commands.RESTART_SERVER), true)
   }).timeout(MaxTimeout)
 
   test('Command: Check Dependencies', async () => {
     await startTerminalEmulator(waitForEmulatorActive, waitForEmulatorClosed)
-    assert.strictEqual(ext?.executeCommand(commands.CHECK_DEPENDENCIES), true)
-    await delay(executionDelay)
+    assert.strictEqual(await ext?.executeCommand(commands.CHECK_DEPENDENCIES), true)
     await closeTerminalEmulator(waitForEmulatorClosed)
   }).timeout(MaxTimeout)
 })


### PR DESCRIPTION
Closes #340

## Description

Made commands in CommandController async so we may wait for their completion/catch errors.  Speeds up tests and removes arbitrary delays.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
