### PR TITLE
Fix langauge server instance leaking between tests

### DIFF
--- a/extension/src/emulator/emulator-controller.ts
+++ b/extension/src/emulator/emulator-controller.ts
@@ -55,7 +55,7 @@ export class EmulatorController {
   }
 
   async restartServer (): Promise<void> {
-    await this.api.reset()
+    await this.api.restart()
     void window.showInformationMessage('Restarted language server')
   }
 

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -69,7 +69,7 @@ export class LanguageServerAPI {
   }
 
   async deactivate (): Promise<void> {
-    let deactivationPromises = [this.#watcherPromise]
+    const deactivationPromises = [this.#watcherPromise]
     if (this.#watcherTimeout != null) {
       clearTimeout(this.#watcherTimeout)
       this.#watcherTimeout = null
@@ -83,19 +83,19 @@ export class LanguageServerAPI {
     const pollingIntervalMs = 1000
 
     // Loop with setTimeout to avoid overlapping calls
-    async function loop (this: LanguageServerAPI) {
+    async function loop (this: LanguageServerAPI): Promise<void> {
       this.#watcherPromise = (async () => {
         try {
           // Wait for client to connect or disconnect
           if (this.clientState$.getValue() === State.Starting) return
-  
+
           // Check if emulator state has changed
           const emulatorFound = await verifyEmulator()
           if ((this.emulatorState$.getValue() === EmulatorState.Connected) === emulatorFound) {
             return // No changes in local emulator state
           }
-  
-          if(this.#watcherTimeout === null) return
+
+          if (this.#watcherTimeout === null) return
 
           // Restart language server
           await this.restart(emulatorFound)
@@ -103,7 +103,6 @@ export class LanguageServerAPI {
           console.log(err)
         }
       })()
-
 
       // Wait for watcher to finish
       await this.#watcherPromise

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -31,6 +31,7 @@ export class LanguageServerAPI {
   emulatorState$ = new BehaviorSubject<EmulatorState>(EmulatorState.Disconnected)
 
   #watcherTimeout: NodeJS.Timeout | null = null
+  #watcherPromise: Promise<void> | null = null
   #flowConfigWatcher: Promise<Disposable> | null = null
 
   constructor (settings: Settings) {
@@ -50,7 +51,9 @@ export class LanguageServerAPI {
           return EmulatorState.Disconnected
         }
       })
-    ).subscribe((state) => this.emulatorState$.next(state))
+    ).subscribe((state) => {
+      this.emulatorState$.next(state)
+    })
 
     // Subscribe to emulator state changes
     this.emulatorState$.subscribe(emulatorStateChanged)
@@ -66,41 +69,60 @@ export class LanguageServerAPI {
   }
 
   async deactivate (): Promise<void> {
-    await this.stopClient()
-    if (this.#watcherTimeout != null) clearTimeout(this.#watcherTimeout)
-    if (this.#flowConfigWatcher != null) (await this.#flowConfigWatcher).dispose()
+    let deactivationPromises = [this.#watcherPromise]
+    if (this.#watcherTimeout != null) {
+      clearTimeout(this.#watcherTimeout)
+      this.#watcherTimeout = null
+    }
+    if (this.#flowConfigWatcher != null) deactivationPromises.push(this.#flowConfigWatcher.then(watcher => watcher.dispose()))
+    deactivationPromises.push(this.stopClient())
+    await Promise.all(deactivationPromises)
   }
 
   watchEmulator (): void {
     const pollingIntervalMs = 1000
 
     // Loop with setTimeout to avoid overlapping calls
-    void (async function loop (this: LanguageServerAPI) {
-      try {
-        // Wait for client to connect or disconnect
-        if (this.clientState$.getValue() === State.Starting) return
+    async function loop (this: LanguageServerAPI) {
+      this.#watcherPromise = (async () => {
+        try {
+          // Wait for client to connect or disconnect
+          if (this.clientState$.getValue() === State.Starting) return
+  
+          // Check if emulator state has changed
+          const emulatorFound = await verifyEmulator()
+          if ((this.emulatorState$.getValue() === EmulatorState.Connected) === emulatorFound) {
+            return // No changes in local emulator state
+          }
+  
+          if(this.#watcherTimeout === null) return
 
-        // Check if emulator state has changed
-        const emulatorFound = await verifyEmulator()
-        if ((this.emulatorState$.getValue() === EmulatorState.Connected) === emulatorFound) {
-          return // No changes in local emulator state
+          // Restart language server
+          await this.restart(emulatorFound)
+        } catch (err) {
+          console.log(err)
         }
+      })()
 
-        // Restart language server
-        await this.restart(emulatorFound)
-      } catch (err) {
-        console.log(err)
-      } finally {
+
+      // Wait for watcher to finish
+      await this.#watcherPromise
+
+      // If watcher hasn't been disposed, restart loop
+      if (this.#watcherTimeout != null) {
         this.#watcherTimeout = setTimeout(() => { void loop.bind(this)() }, pollingIntervalMs)
       }
-    }.bind(this))()
+    }
+
+    // Start loop, must be a timeout for aborts to work
+    this.#watcherTimeout = setTimeout(() => { void loop.bind(this)() }, 0)
   }
 
   async startClient (enableFlow?: boolean): Promise<void> {
     // Prevent starting multiple times
     if (this.clientState$.getValue() === State.Starting) {
-      await firstValueFrom(this.clientState$.pipe(filter(state => state !== State.Starting)))
-      if (this.clientState$.getValue() === State.Running) { return }
+      const newState = await firstValueFrom(this.clientState$.pipe(filter(state => state !== State.Starting)))
+      if (newState === State.Running) { return }
     } else if (this.clientState$.getValue() === State.Running) {
       return
     }
@@ -178,7 +200,7 @@ export class LanguageServerAPI {
     this.client = null
   }
 
-  async restart (enableFlow: boolean): Promise<void> {
+  async restart (enableFlow?: boolean): Promise<void> {
     // Prevent restarting multiple times
     await this.stopClient()
     await this.startClient(enableFlow)
@@ -193,11 +215,6 @@ export class LanguageServerAPI {
       command: cmd,
       arguments: args
     })
-  }
-
-  async reset (): Promise<void> {
-    const enableFlow = await verifyEmulator()
-    await this.restart(enableFlow)
   }
 
   // Sends a request to switch the currently active account.


### PR DESCRIPTION
Closes #349 

## Description

These errors appearing in CI were actually caused by language server instances leaking between tests.  The objects were not being disposed of correctly, causing them to compete for the emulator connection & other resources.  This explained the proposal key sequence number issues as well.

This PR fixes the deactivation of the LS & ensures that all necessary tasks are properly awaited.  The main culprit here was the emulator watcher loop not being cleaned up properly (timeout was cleared, but the async function had already started).

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
