### PR TITLE
Add semver to package.json & bump to 7.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"object-hash": "^3.0.0",
 				"os-name": "^5.0.1",
 				"rxjs": "^7.8.1",
+				"semver": "^7.5.1",
 				"sleep-synchronously": "^2.0.0",
 				"uuid": "^9.0.0",
 				"vscode-languageclient": "8.0.2"
@@ -31,7 +32,7 @@
 				"@types/mocha": "^10.0.1",
 				"@types/node": "^20.2.5",
 				"@types/object-hash": "^3.0.2",
-				"@types/semver": "^7.3.13",
+				"@types/semver": "^7.5.0",
 				"@types/uuid": "^9.0.0",
 				"@types/vscode": "^1.65.0",
 				"@vscode/test-electron": "^2.3.2",
@@ -979,9 +980,9 @@
 			"dev": true
 		},
 		"node_modules/@types/semver": {
-			"version": "7.3.13",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-			"integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+			"integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
 			"dev": true
 		},
 		"node_modules/@types/stack-utils": {
@@ -1048,21 +1049,6 @@
 				"typescript": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
@@ -1176,21 +1162,6 @@
 				}
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "5.48.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.48.2.tgz",
@@ -1215,21 +1186,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
@@ -1262,21 +1218,6 @@
 			},
 			"engines": {
 				"node": ">=16"
-			}
-		},
-		"node_modules/@vscode/test-electron/node_modules/semver": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@vscode/vsce": {
@@ -1332,6 +1273,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@vscode/vsce/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@vscode/vsce/node_modules/xml2js": {
@@ -1815,21 +1764,6 @@
 			"dev": true,
 			"dependencies": {
 				"semver": "^7.0.0"
-			}
-		},
-		"node_modules/builtins/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/caching-transform": {
@@ -2957,21 +2891,6 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-n/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/eslint-plugin-promise": {
@@ -5875,21 +5794,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/node-abi/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"optional": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
@@ -6416,6 +6320,15 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/ovsx/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -6522,6 +6435,14 @@
 			"integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
 			"dependencies": {
 				"semver": "^5.1.0"
+			}
+		},
+		"node_modules/parse-semver/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/parse5": {
@@ -7136,11 +7057,17 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"node_modules/semver": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
 			"bin": {
-				"semver": "bin/semver"
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/serialize-javascript": {
@@ -8161,20 +8088,6 @@
 			},
 			"engines": {
 				"vscode": "^1.67.0"
-			}
-		},
-		"node_modules/vscode-languageclient/node_modules/semver": {
-			"version": "7.3.8",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-			"integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/vscode-languageserver-protocol": {

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^20.2.5",
 		"@types/object-hash": "^3.0.2",
-		"@types/semver": "^7.3.13",
+		"@types/semver": "^7.5.0",
 		"@types/uuid": "^9.0.0",
 		"@types/vscode": "^1.65.0",
 		"@vscode/test-electron": "^2.3.2",
@@ -231,6 +231,7 @@
 		"object-hash": "^3.0.0",
 		"os-name": "^5.0.1",
 		"rxjs": "^7.8.1",
+		"semver": "^7.5.1",
 		"sleep-synchronously": "^2.0.0",
 		"uuid": "^9.0.0",
 		"vscode-languageclient": "8.0.2"


### PR DESCRIPTION
We are using functionality from semver but it's not tracked it package.json and instead comes as a dependency of other packages.  This probably should not be done (for version control amongst other reasons) so this PR adds it to the package.json and bumps it to 7.5.1 as we were technically using v6 from @babel/core previously by the looks of it.