### PR TITLE
Disable hardware acceleration to fix Windows tests

### DIFF
--- a/extension/test/run-tests.ts
+++ b/extension/test/run-tests.ts
@@ -12,7 +12,7 @@ async function main (): Promise<void> {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: [testWorkspace, '--disable-telemetry']
+      launchArgs: [testWorkspace, '--disable-telemetry', '--disable-gpu', '--disable-software-rasterizer']
     })
   } catch (err) {
     console.error('Failed to run tests')


### PR DESCRIPTION
Closes #358 

This disables hardware acceleration in tests which seems to be the likely culprit of the transient failures experienced in Windows.

It kind of appears that this is something fixed in newer versions of electron but until we bump the VSCode engine version, this fix will likely be required.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
