### PR TITLE
Fix schema URL typo

### DIFF
--- a/extension/src/json-schema-provider.ts
+++ b/extension/src/json-schema-provider.ts
@@ -26,7 +26,7 @@ export class JSONSchemaProvider implements vscode.FileSystemProvider, vscode.Dis
       JSONSchemaProvider.#instance.dispose()
     }
 
-    // Create a provider for the flow-schema URI scheme, this will be deactivated when the extension is deactivated
+    // Create a provider for the cadence-schema URI scheme, this will be deactivated when the extension is deactivated
     JSONSchemaProvider.#instance = new JSONSchemaProvider(
       ctx,
       flowVersion,
@@ -105,7 +105,7 @@ export class JSONSchemaProvider implements vscode.FileSystemProvider, vscode.Dis
     }).catch(async () => {
       // Fallback to local schema
       this.#showLocalError = true
-      const schemaUrl = resolve(this.ctx.extensionPath, 'flow-schema.json')
+      const schemaUrl = resolve(this.ctx.extensionPath, 'schema.json')
       return await promisify(readFile)(schemaUrl).then(x => x.toString())
     })
   }

--- a/extension/src/json-schema-provider.ts
+++ b/extension/src/json-schema-provider.ts
@@ -105,7 +105,7 @@ export class JSONSchemaProvider implements vscode.FileSystemProvider, vscode.Dis
     }).catch(async () => {
       // Fallback to local schema
       this.#showLocalError = true
-      const schemaUrl = resolve(this.ctx.extensionPath, 'schema.json')
+      const schemaUrl = resolve(this.ctx.extensionPath, 'flow-schema.json')
       return await promisify(readFile)(schemaUrl).then(x => x.toString())
     })
   }

--- a/extension/src/json-schema-provider.ts
+++ b/extension/src/json-schema-provider.ts
@@ -7,7 +7,7 @@ import fetch from 'node-fetch'
 import { StateCache } from './utils/state-cache'
 import { Subscription } from 'rxjs'
 
-const GET_FLOW_SCHEMA_URL = (version: SemVer): string => `https://raw.githubusercontent.com/onflow/flow-cli/v${version.format()}/flowkit/flow-schema.json`
+const GET_FLOW_SCHEMA_URL = (version: SemVer): string => `https://raw.githubusercontent.com/onflow/flow-cli/v${version.format()}/flowkit/schema.json`
 
 // This class provides the JSON schema for the flow.json file
 // It is accessible via the URI scheme "cadence-schema:///flow.json"

--- a/extension/test/integration/4 - schema.test.ts
+++ b/extension/test/integration/4 - schema.test.ts
@@ -69,7 +69,7 @@ suite('JSON schema tests', () => {
 
     // Assert that the schema is the same as the local schema
     await vscode.workspace.fs.readFile(vscode.Uri.parse('cadence-schema:///flow.json')).then((data) => {
-      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './schema.json'), 'utf-8'))
+      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './flow-schema.json'), 'utf-8'))
     })
   }).timeout(MaxTimeout)
 
@@ -79,7 +79,7 @@ suite('JSON schema tests', () => {
 
     // Assert that the schema is the same as the local schema
     await vscode.workspace.fs.readFile(vscode.Uri.parse('cadence-schema:///flow.json')).then((data) => {
-      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './schema.json'), 'utf-8'))
+      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './flow-schema.json'), 'utf-8'))
     })
   }).timeout(MaxTimeout)
 

--- a/extension/test/integration/4 - schema.test.ts
+++ b/extension/test/integration/4 - schema.test.ts
@@ -33,7 +33,7 @@ suite('JSON schema tests', () => {
     ;(fetch as unknown as any).default = async (url: string) => {
       // only mock valid response for version 1.0.0 for testing
       // other versions will return 404 and emulate a missing schema
-      if (url === 'https://raw.githubusercontent.com/onflow/flow-cli/v1.0.0/flowkit/flow-schema.json') {
+      if (url === 'https://raw.githubusercontent.com/onflow/flow-cli/v1.0.0/flowkit/schema.json') {
         return {
           ok: true,
           text: async () => JSON.stringify({
@@ -69,7 +69,7 @@ suite('JSON schema tests', () => {
 
     // Assert that the schema is the same as the local schema
     await vscode.workspace.fs.readFile(vscode.Uri.parse('cadence-schema:///flow.json')).then((data) => {
-      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './flow-schema.json'), 'utf-8'))
+      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './schema.json'), 'utf-8'))
     })
   }).timeout(MaxTimeout)
 
@@ -79,7 +79,7 @@ suite('JSON schema tests', () => {
 
     // Assert that the schema is the same as the local schema
     await vscode.workspace.fs.readFile(vscode.Uri.parse('cadence-schema:///flow.json')).then((data) => {
-      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './flow-schema.json'), 'utf-8'))
+      assert.strictEqual(data.toString(), readFileSync(path.resolve(mockContext.extensionPath, './schema.json'), 'utf-8'))
     })
   }).timeout(MaxTimeout)
 


### PR DESCRIPTION
Fixes a typo in the flow.json schema URL that was causing the schema to fail to be resolved