### PR TITLE
Handle edge cases when watching for flow.json changes

### DIFF
--- a/extension/src/emulator/local/flowConfig.ts
+++ b/extension/src/emulator/local/flowConfig.ts
@@ -168,11 +168,11 @@ async function readLocalConfig (): Promise<string> {
 }
 
 export async function watchFlowConfigChanges (changedEvent: () => {}): Promise<Disposable> {
-  const watchPath = await getConfigPath().catch(() => "**/flow.json")
+  const watchPath = await getConfigPath().catch(() => '**/flow.json')
   const configWatcher = workspace.createFileSystemWatcher(watchPath)
 
   let updateDelay: any = null
-  function watcherHandler(e: Uri) {
+  function watcherHandler (e: Uri): void {
     // request deduplication - we do this to avoid spamming requests in a short time period but rather aggragete into one
     if (updateDelay == null) {
       updateDelay = setTimeout(() => {

--- a/extension/src/emulator/local/flowConfig.ts
+++ b/extension/src/emulator/local/flowConfig.ts
@@ -124,8 +124,15 @@ async function readLocalConfig (): Promise<string> {
       if (path.isAbsolute(settings.customConfigPath)) {
         configFilePath = settings.customConfigPath
       } else {
+        // Find all files matching relative path in workspace
         const files = workspace.workspaceFolders.reduce<string[]>(
-          (res, folder) => ([...res, path.resolve(folder.uri.fsPath, settings.customConfigPath)]),
+          (res, folder) => {
+            const filePath = path.resolve(folder.uri.fsPath, settings.customConfigPath)
+            if (fs.existsSync(filePath)) {
+              res.push(filePath)
+            }
+            return res
+          },
           []
         )
         if (files.length === 1) {

--- a/extension/src/emulator/local/flowConfig.ts
+++ b/extension/src/emulator/local/flowConfig.ts
@@ -105,7 +105,6 @@ async function promptInitializeConfig (): Promise<void> {
     void window.showErrorMessage('Failed to initialize Flow CLI configuration.')
   } else {
     void window.showInformationMessage('Flow CLI configuration created.')
-    flowConfig.invalidate()
   }
 }
 
@@ -168,6 +167,8 @@ async function readLocalConfig (): Promise<string> {
 }
 
 export async function watchFlowConfigChanges (changedEvent: () => {}): Promise<Disposable> {
+  // Watch for changes to config file
+  // If it does not exist, wait for flow.json to be created
   const watchPath = await getConfigPath().catch(() => '**/flow.json')
   const configWatcher = workspace.createFileSystemWatcher(watchPath)
 
@@ -176,7 +177,6 @@ export async function watchFlowConfigChanges (changedEvent: () => {}): Promise<D
     // request deduplication - we do this to avoid spamming requests in a short time period but rather aggragete into one
     if (updateDelay == null) {
       updateDelay = setTimeout(() => {
-        flowConfig.invalidate()
         changedEvent()
         updateDelay = null
       }, 500)

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -253,6 +253,8 @@ export class LanguageServerAPI {
 
     // Watch for changes to flow configuration
     this.#flowConfigWatcher = Config.watchFlowConfigChanges(async () => {
+      Config.flowConfig.invalidate()
+
       // Reload configuration command is only available when flow integration is enabled
       if (!this.flowEnabled$.getValue()) return
 

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -64,7 +64,7 @@ export class LanguageServerAPI {
   async activate (): Promise<void> {
     await this.deactivate()
     this.watchEmulator()
-    console.log("activate")
+    console.log('activate')
     await this.watchFlowConfiguration()
   }
 
@@ -107,7 +107,7 @@ export class LanguageServerAPI {
           // Restart language server
           await this.restart(emulatorFound)
         } catch (err) {
-          //or(err)
+          // or(err)
         }
       })()
 
@@ -258,7 +258,7 @@ export class LanguageServerAPI {
       if (!this.flowEnabled$.getValue()) return
 
       // Reload configuration
-      console.log("RELOADING CONFIGURATION")
+      console.log('RELOADING CONFIGURATION')
       if (this.clientState$.getValue() === State.Running) {
         await this.#sendRequest(RELOAD_CONFIGURATION)
       } else if (this.clientState$.getValue() === State.Starting) {

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -245,6 +245,7 @@ export class LanguageServerAPI {
     // Configure subscriber to reset watcher on flow configuration change
     this.#workspaceSettingsSubscriber?.unsubscribe()
     this.#workspaceSettingsSubscriber = Settings.getWorkspaceSettings().didChange$.subscribe(() => {
+      Config.flowConfig.invalidate()
       void this.watchFlowConfiguration()
     })
 

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -243,7 +243,7 @@ export class LanguageServerAPI {
   async watchFlowConfiguration (): Promise<void> {
     // Configure subscriber to reset watcher on flow configuration change
     this.#workspaceSettingsSubscriber?.unsubscribe()
-    this.#workspaceSettingsSubscriber = Settings.getWorkspaceSettings().didChange$.subscribe(() => {
+    this.#workspaceSettingsSubscriber = this.settings.didChange$.subscribe(() => {
       Config.flowConfig.invalidate()
       void this.watchFlowConfiguration()
     })

--- a/extension/src/emulator/server/language-server.ts
+++ b/extension/src/emulator/server/language-server.ts
@@ -64,7 +64,6 @@ export class LanguageServerAPI {
   async activate (): Promise<void> {
     await this.deactivate()
     this.watchEmulator()
-    console.log('activate')
     await this.watchFlowConfiguration()
   }
 
@@ -107,7 +106,7 @@ export class LanguageServerAPI {
           // Restart language server
           await this.restart(emulatorFound)
         } catch (err) {
-          // or(err)
+          console.error(err)
         }
       })()
 
@@ -258,7 +257,6 @@ export class LanguageServerAPI {
       if (!this.flowEnabled$.getValue()) return
 
       // Reload configuration
-      console.log('RELOADING CONFIGURATION')
       if (this.clientState$.getValue() === State.Running) {
         await this.#sendRequest(RELOAD_CONFIGURATION)
       } else if (this.clientState$.getValue() === State.Starting) {

--- a/extension/src/settings/settings.ts
+++ b/extension/src/settings/settings.ts
@@ -1,8 +1,12 @@
 /* Workspace Settings */
-import { Observable, Subject } from 'rxjs'
 import { workspace, window } from 'vscode'
 
 export class Settings {
+  static CONFIG_FLOW_COMMAND = 'flowCommand'
+  static CONFIG_NUM_ACCOUNTS = 'numAccounts'
+  static CONFIG_ACCESS_CHECK_MODE = 'accessCheckMode'
+  static CONFIG_CUSTOM_CONFIG_PATH = 'customConfigPath'
+
   // Workspace settings singleton
   static #instance: Settings | undefined
 
@@ -49,25 +53,33 @@ export class Settings {
     // Retrieve workspace settings
     const cadenceConfig = workspace.getConfiguration('cadence')
 
-    const flowCommand: string | undefined = cadenceConfig.get('flowCommand')
+    const flowCommand: string | undefined = cadenceConfig.get(
+      Settings.CONFIG_FLOW_COMMAND
+    )
     if (flowCommand === undefined) {
-      throw new Error('Missing flowCommand config')
+      throw new Error(`Missing ${Settings.CONFIG_FLOW_COMMAND} config`)
     }
     this.flowCommand = flowCommand
 
-    let numAccounts: number | undefined = cadenceConfig.get('numAccounts')
+    let numAccounts: number | undefined = cadenceConfig.get(
+      Settings.CONFIG_NUM_ACCOUNTS
+    )
     if (numAccounts === undefined || numAccounts <= 0) {
       numAccounts = 3
     }
     this.numAccounts = numAccounts
 
-    let accessCheckMode: string | undefined = cadenceConfig.get('accessCheckMode')
+    let accessCheckMode: string | undefined = cadenceConfig.get(
+      Settings.CONFIG_ACCESS_CHECK_MODE
+    )
     if (accessCheckMode === undefined) {
       accessCheckMode = 'strict'
     }
     this.accessCheckMode = accessCheckMode
 
-    let customConfigPath: string | undefined = cadenceConfig.get('customConfigPath')
+    let customConfigPath: string | undefined = cadenceConfig.get(
+      Settings.CONFIG_CUSTOM_CONFIG_PATH
+    )
     if (customConfigPath === undefined) {
       customConfigPath = ''
     }

--- a/extension/src/settings/settings.ts
+++ b/extension/src/settings/settings.ts
@@ -1,13 +1,6 @@
 /* Workspace Settings */
-import { Subject } from 'rxjs'
-import { workspace, window, WorkspaceConfiguration } from 'vscode'
-
-export interface CadenceConfiguration extends WorkspaceConfiguration {
-  flowCommand: string
-  numAccounts: number
-  accessCheckMode: string
-  customConfigPath: string
-}
+import { Observable, Subject } from 'rxjs'
+import { workspace, window } from 'vscode'
 
 export class Settings {
   // Workspace settings singleton
@@ -19,7 +12,7 @@ export class Settings {
   customConfigPath!: string // If empty then search the workspace for flow.json
 
   #didChange: Subject<void> = new Subject()
-  get didChange$ () {
+  get didChange$ (): Observable<void> {
     return this.#didChange.asObservable()
   }
 
@@ -43,45 +36,38 @@ export class Settings {
 
     // Watch for workspace settings changes
     workspace.onDidChangeConfiguration((e) => {
-      if(e.affectsConfiguration('cadence')) {
-        /*if(e.affectsConfiguration('cadence.flowCommand')) {
-          const flowCommand: string | undefined = workspace.getConfiguration('cadence').get(Settings.CONFIG_FLOW_COMMAND)
-          if (flowCommand === undefined) {
-            throw new Error(`Missing ${Settings.CONFIG_FLOW_COMMAND} config`)
-          }
-          this.flowCommand = flowCommand
-        }*/
-        this.loadSettings()
+      if (e.affectsConfiguration('cadence')) {
+        this.#loadSettings()
         this.#didChange.next()
       }
     })
 
-    this.loadSettings()
+    this.#loadSettings()
   }
 
-  loadSettings() {
+  #loadSettings (): void {
     // Retrieve workspace settings
-    const cadenceConfig: CadenceConfiguration = workspace.getConfiguration('cadence') as CadenceConfiguration
+    const cadenceConfig = workspace.getConfiguration('cadence')
 
-    const flowCommand: string | undefined = cadenceConfig.flowCommand
+    const flowCommand: string | undefined = cadenceConfig.get('flowCommand')
     if (flowCommand === undefined) {
-      throw new Error(`Missing flowCommand config`)
+      throw new Error('Missing flowCommand config')
     }
     this.flowCommand = flowCommand
 
-    let numAccounts: number | undefined = cadenceConfig.numAccounts
+    let numAccounts: number | undefined = cadenceConfig.get('numAccounts')
     if (numAccounts === undefined || numAccounts <= 0) {
       numAccounts = 3
     }
     this.numAccounts = numAccounts
 
-    let accessCheckMode: string | undefined = cadenceConfig.accessCheckMode
+    let accessCheckMode: string | undefined = cadenceConfig.get('accessCheckMode')
     if (accessCheckMode === undefined) {
       accessCheckMode = 'strict'
     }
     this.accessCheckMode = accessCheckMode
 
-    let customConfigPath: string | undefined = cadenceConfig.customConfigPath
+    let customConfigPath: string | undefined = cadenceConfig.get('customConfigPath')
     if (customConfigPath === undefined) {
       customConfigPath = ''
     }

--- a/extension/src/settings/settings.ts
+++ b/extension/src/settings/settings.ts
@@ -1,12 +1,15 @@
 /* Workspace Settings */
-import { workspace, window } from 'vscode'
+import { Subject } from 'rxjs'
+import { workspace, window, WorkspaceConfiguration } from 'vscode'
+
+export interface CadenceConfiguration extends WorkspaceConfiguration {
+  flowCommand: string
+  numAccounts: number
+  accessCheckMode: string
+  customConfigPath: string
+}
 
 export class Settings {
-  static CONFIG_FLOW_COMMAND = 'flowCommand'
-  static CONFIG_NUM_ACCOUNTS = 'numAccounts'
-  static CONFIG_ACCESS_CHECK_MODE = 'accessCheckMode'
-  static CONFIG_CUSTOM_CONFIG_PATH = 'customConfigPath'
-
   // Workspace settings singleton
   static #instance: Settings | undefined
 
@@ -14,6 +17,11 @@ export class Settings {
   numAccounts!: number
   accessCheckMode!: string
   customConfigPath!: string // If empty then search the workspace for flow.json
+
+  #didChange: Subject<void> = new Subject()
+  get didChange$ () {
+    return this.#didChange.asObservable()
+  }
 
   static getWorkspaceSettings (): Settings {
     if (Settings.#instance === undefined) {
@@ -32,36 +40,48 @@ export class Settings {
     if (skipInitialization !== undefined && skipInitialization) {
       return
     }
-    // Retrieve workspace settings
-    const cadenceConfig = workspace.getConfiguration('cadence')
 
-    const flowCommand: string | undefined = cadenceConfig.get(
-      Settings.CONFIG_FLOW_COMMAND
-    )
+    // Watch for workspace settings changes
+    workspace.onDidChangeConfiguration((e) => {
+      if(e.affectsConfiguration('cadence')) {
+        /*if(e.affectsConfiguration('cadence.flowCommand')) {
+          const flowCommand: string | undefined = workspace.getConfiguration('cadence').get(Settings.CONFIG_FLOW_COMMAND)
+          if (flowCommand === undefined) {
+            throw new Error(`Missing ${Settings.CONFIG_FLOW_COMMAND} config`)
+          }
+          this.flowCommand = flowCommand
+        }*/
+        this.loadSettings()
+        this.#didChange.next()
+      }
+    })
+
+    this.loadSettings()
+  }
+
+  loadSettings() {
+    // Retrieve workspace settings
+    const cadenceConfig: CadenceConfiguration = workspace.getConfiguration('cadence') as CadenceConfiguration
+
+    const flowCommand: string | undefined = cadenceConfig.flowCommand
     if (flowCommand === undefined) {
-      throw new Error(`Missing ${Settings.CONFIG_FLOW_COMMAND} config`)
+      throw new Error(`Missing flowCommand config`)
     }
     this.flowCommand = flowCommand
 
-    let numAccounts: number | undefined = cadenceConfig.get(
-      Settings.CONFIG_NUM_ACCOUNTS
-    )
+    let numAccounts: number | undefined = cadenceConfig.numAccounts
     if (numAccounts === undefined || numAccounts <= 0) {
       numAccounts = 3
     }
     this.numAccounts = numAccounts
 
-    let accessCheckMode: string | undefined = cadenceConfig.get(
-      Settings.CONFIG_ACCESS_CHECK_MODE
-    )
+    let accessCheckMode: string | undefined = cadenceConfig.accessCheckMode
     if (accessCheckMode === undefined) {
       accessCheckMode = 'strict'
     }
     this.accessCheckMode = accessCheckMode
 
-    let customConfigPath: string | undefined = cadenceConfig.get(
-      Settings.CONFIG_CUSTOM_CONFIG_PATH
-    )
+    let customConfigPath: string | undefined = cadenceConfig.customConfigPath
     if (customConfigPath === undefined) {
       customConfigPath = ''
     }

--- a/extension/src/settings/settings.ts
+++ b/extension/src/settings/settings.ts
@@ -1,4 +1,5 @@
 /* Workspace Settings */
+import { Observable, Subject } from 'rxjs'
 import { workspace, window } from 'vscode'
 
 export class Settings {


### PR DESCRIPTION
Closes #406 

This fixes the issue at hand.  Now when I delete, create, update, change settings, etc. the correct flow.json is always in use and the emulator connects - there is no longer any issue with the extension breaking.

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
