### PR TITLE
Fix Cadence Testing bug when packaged in VSIX

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -61,7 +61,7 @@ export class Extension {
 
     // Initialize TestProvider
     const extensionPath = ctx?.extensionPath ?? ''
-    const parserLocation = path.resolve(extensionPath, 'node_modules/@onflow/cadence-parser/dist/cadence-parser.wasm')
+    const parserLocation = path.resolve(extensionPath, 'out/extension/cadence-parser.wasm')
     this.#testProvider = new TestProvider(parserLocation, settings, flowConfig)
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cadence",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cadence",
-			"version": "2.1.0",
+			"version": "2.1.1",
 			"dependencies": {
 				"@onflow/cadence-parser": "^0.42.1",
 				"@onflow/decode": "0.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cadence",
-	"version": "2.1.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cadence",
-			"version": "2.1.0",
+			"version": "2.0.1",
 			"dependencies": {
 				"@onflow/cadence-parser": "^0.42.1",
 				"@onflow/decode": "0.0.11",
@@ -38,7 +38,7 @@
 				"@types/sinon": "^17.0.1",
 				"@types/uuid": "^9.0.7",
 				"@types/vscode": "^1.65.0",
-				"@vscode/test-electron": "^2.3.4",
+				"@vscode/test-electron": "^2.3.8",
 				"chai": "^4.3.10",
 				"esbuild": "^0.19.9",
 				"glob": "^10.3.10",
@@ -1662,9 +1662,9 @@
 			}
 		},
 		"node_modules/@vscode/test-electron": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.4.tgz",
-			"integrity": "sha512-eWzIqXMhvlcoXfEFNWrVu/yYT5w6De+WZXR/bafUQhAp8+8GkQo95Oe14phwiRUPv8L+geAKl/QM2+PoT3YW3g==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.8.tgz",
+			"integrity": "sha512-b4aZZsBKtMGdDljAsOPObnAi7+VWIaYl3ylCz1jTs+oV6BZ4TNHcVNC3xUn0azPeszBmwSBDQYfFESIaUQnrOg==",
 			"dev": true,
 			"dependencies": {
 				"http-proxy-agent": "^4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cadence",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cadence",
-			"version": "2.0.1",
+			"version": "2.1.0",
 			"dependencies": {
 				"@onflow/cadence-parser": "^0.42.1",
 				"@onflow/decode": "0.0.11",
@@ -42,6 +42,7 @@
 				"chai": "^4.3.10",
 				"esbuild": "^0.19.9",
 				"glob": "^10.3.10",
+				"mkdirp": "^3.0.1",
 				"mocha": "^10.2.0",
 				"nyc": "^15.1.0",
 				"ovsx": "^0.8.3",
@@ -6102,15 +6103,18 @@
 			}
 		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
 			"bin": {
-				"mkdirp": "bin/cmd.js"
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mkdirp-classic": {
@@ -8519,6 +8523,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/ts-mocha/node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/ts-mocha/node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run -S esbuild-base -- --minify",
-		"esbuild-base": "esbuild ./extension/src/main.ts --bundle --outfile=out/extension/src/main.js --external:vscode --format=cjs --platform=node",
+		"esbuild-base": "mkdirp ./out/extension && cp ./node_modules/@onflow/cadence-parser/dist/cadence-parser.wasm ./out/extension && esbuild ./extension/src/main.ts --bundle --outfile=out/extension/src/main.js --external:vscode --format=cjs --platform=node",
 		"esbuild": "npm run -S esbuild-base -- --sourcemap",
 		"esbuild-watch": "npm run -S esbuild-base -- --sourcemap --watch",
 		"check": "tsc extension/src/main.ts",
@@ -194,6 +194,7 @@
 		"chai": "^4.3.10",
 		"esbuild": "^0.19.9",
 		"glob": "^10.3.10",
+		"mkdirp": "^3.0.1",
 		"mocha": "^10.2.0",
 		"nyc": "^15.1.0",
 		"ovsx": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Cadence",
 	"publisher": "onflow",
 	"description": "This extension integrates Cadence, the resource-oriented smart contract programming language of Flow, into Visual Studio Code.",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/onflow/vscode-cadence.git"

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 		"@types/sinon": "^17.0.1",
 		"@types/uuid": "^9.0.7",
 		"@types/vscode": "^1.65.0",
-		"@vscode/test-electron": "^2.3.4",
+		"@vscode/test-electron": "^2.3.8",
 		"chai": "^4.3.10",
 		"esbuild": "^0.19.9",
 		"glob": "^10.3.10",


### PR DESCRIPTION
Fixes bug that only exists in production/when extension is packaged.  Node modules don't come with the extension bundle so the WASM file needs to be manually copied to the extension output