### PR TITLE
Reload the LS when relevant config changes

### DIFF
--- a/extension/src/main.ts
+++ b/extension/src/main.ts
@@ -19,7 +19,7 @@ export async function activate (ctx: ExtensionContext): Promise<Extension | null
 
   // Initialize the extension
   Telemetry.withTelemetry(() => {
-    const settings = Settings.getWorkspaceSettings()
+    const settings = new Settings()
     ext = Extension.initialize(settings, ctx)
   })
 

--- a/extension/src/server/flow-config.ts
+++ b/extension/src/server/flow-config.ts
@@ -102,7 +102,7 @@ export class FlowConfig implements Disposable {
   }
 
   #resolveCustomConfigPath (): FlowConfigFile | null {
-    const customConfigPath = this.#settings.customConfigPath
+    const customConfigPath = this.#settings.getSettings().customConfigPath
     if (customConfigPath === null || customConfigPath === '') {
       return null
     }
@@ -172,7 +172,7 @@ export class FlowConfig implements Disposable {
 
   // Watch and reload flow configuration when changed.
   #watchWorkspaceConfiguration (): Subscription {
-    return this.#settings.didChange$.subscribe(() => {
+    return this.#settings.watch$(config => config.customConfigPath).subscribe(() => {
       void this.reloadConfigPath()
     })
   }

--- a/extension/test/integration/6 - test-provider.test.ts
+++ b/extension/test/integration/6 - test-provider.test.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode'
 import * as sinon from 'sinon'
 import * as assert from 'assert'
 import * as fs from 'fs'
+import { getMockSettings } from '../mock/mockSettings'
 
 const workspacePath = path.resolve(__dirname, './fixtures/workspace')
 
@@ -22,11 +23,12 @@ suite('test provider tests', () => {
 
     const parserLocation = path.resolve(__dirname, '../../../../node_modules/@onflow/cadence-parser/dist/cadence-parser.wasm')
 
-    mockSettings = {
-      maxTestConcurrency: 5,
+    mockSettings = getMockSettings({
       flowCommand: 'flow',
-      didChange$: of()
-    } as any
+      test: {
+        maxConcurrency: 1
+      }
+    })
     mockConfig = {
       fileModified$: of(),
       pathChanged$: of(),

--- a/extension/test/mock/mockSettings.ts
+++ b/extension/test/mock/mockSettings.ts
@@ -1,10 +1,32 @@
-import { Settings } from '../../src/settings/settings'
+import { BehaviorSubject, Observable, of, map, distinctUntilChanged, skip } from 'rxjs'
+import { CadenceConfiguration, Settings } from '../../src/settings/settings'
 import * as path from 'path'
+import { isEqual } from 'lodash'
 
-export function getMockSettings (): Settings {
-  const mockSettings: Settings = new Settings(true)
-  mockSettings.accessCheckMode = 'strict'
-  mockSettings.customConfigPath = path.join(__dirname, '../integration/fixtures/workspace/flow.json')
-  mockSettings.flowCommand = 'flow'
+export function getMockSettings (settings$: BehaviorSubject<Partial<CadenceConfiguration>> | Partial<CadenceConfiguration> | null = null): Settings {
+  const mockSettings: Settings = { getSettings, watch$ } as any
+
+  function getSettings (): Partial<CadenceConfiguration> {
+    if (!(settings$ instanceof BehaviorSubject) && settings$ != null) return settings$
+
+    return settings$?.getValue() ?? {
+      flowCommand: 'flow',
+      accessCheckMode: 'strict',
+      customConfigPath: path.join(__dirname, '../integration/fixtures/workspace/flow.json'),
+      test: {
+        maxConcurrency: 1
+      }
+    }
+  }
+
+  function watch$<T = CadenceConfiguration> (selector: (config: CadenceConfiguration) => T = (config) => config as unknown as T): Observable<T> {
+    if (!(settings$ instanceof BehaviorSubject)) return of()
+
+    return settings$.asObservable().pipe(
+      skip(1),
+      map(selector as any),
+      distinctUntilChanged(isEqual)
+    )
+  }
   return mockSettings
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"async-lock": "^1.4.0",
 				"crypto": "^1.0.1",
 				"elliptic": "^6.5.4",
+				"lodash": "^4.17.21",
 				"mixpanel": "^0.18.0",
 				"node-fetch": "^2.6.1",
 				"object-hash": "^3.0.0",
@@ -30,6 +31,7 @@
 				"@types/chai": "^4.3.11",
 				"@types/expect": "^24.3.0",
 				"@types/glob": "^8.0.1",
+				"@types/lodash": "^4.14.202",
 				"@types/mixpanel": "^2.14.8",
 				"@types/mocha": "^10.0.1",
 				"@types/node": "^20.10.5",
@@ -37,7 +39,7 @@
 				"@types/semver": "^7.5.6",
 				"@types/sinon": "^17.0.1",
 				"@types/uuid": "^9.0.7",
-				"@types/vscode": "^1.85.0",
+				"@types/vscode": "^1.82.0",
 				"@vscode/test-electron": "^2.3.8",
 				"chai": "^4.3.10",
 				"esbuild": "^0.19.9",
@@ -54,7 +56,7 @@
 				"typescript": "~5.1.6"
 			},
 			"engines": {
-				"vscode": "^1.65.0"
+				"vscode": "^1.82.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1385,6 +1387,12 @@
 			"version": "0.0.29",
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+			"dev": true
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.14.202",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+			"integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
 			"dev": true
 		},
 		"node_modules/@types/minimatch": {
@@ -5790,6 +5798,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.flattendeep": {
 			"version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 					"description": "Enter a custom flow.json path, or leave empty for the default config search.",
 					"scope": "resource"
 				},
-				"cadence.maxTestConcurrency": {
+				"cadence.test.maxConcurrency": {
 					"type": "number",
 					"default": "5",
 					"description": "The maximum number of test files that can be run concurrently.",
@@ -182,6 +182,7 @@
 		"@types/chai": "^4.3.11",
 		"@types/expect": "^24.3.0",
 		"@types/glob": "^8.0.1",
+		"@types/lodash": "^4.14.202",
 		"@types/mixpanel": "^2.14.8",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^20.10.5",
@@ -214,6 +215,7 @@
 		"async-lock": "^1.4.0",
 		"crypto": "^1.0.1",
 		"elliptic": "^6.5.4",
+		"lodash": "^4.17.21",
 		"mixpanel": "^0.18.0",
 		"node-fetch": "^2.6.1",
 		"object-hash": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Cadence",
 	"publisher": "onflow",
 	"description": "This extension integrates Cadence, the resource-oriented smart contract programming language of Flow, into Visual Studio Code.",
-	"version": "2.1.1",
+	"version": "2.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/onflow/vscode-cadence.git"


### PR DESCRIPTION
Closes #494 

## Description

 - Some refactoring to the Settings class (it was kind of bloated and all of the stuff for missing values, defaults, etc. is useless since it's handled by VSCode itself).  The singleton was also kind of useless because we were injecting instances everywhere anyways and only complicates testing
 - Adds a reload to LS when LS-related configuration changes (important for Cadence 1.0, since users will be changing `cadence.flowCommand` setting)
 - Changes test concurrency setting to `test.maxConcurrency` instead.  This was an oversight when I originally added the feature, it probably makes sense to start getting in the habit of namespacing properly.

Imo if specific settings require additional transformations, etc. we can move these to their own sub-providers but the top-level settings provider should be more generalized

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
