### PR TITLE
Relax Flow CLI version parsing requirements & make RegExp more generalized

### DIFF
--- a/extension/src/utils/flow-version.ts
+++ b/extension/src/utils/flow-version.ts
@@ -30,14 +30,14 @@ async function fetchFlowVersion (): Promise<semver.SemVer | null> {
 export function extractFlowCLIVersion (buffer: Buffer | string): string | null {
   const output = buffer.toString()
 
-  const versionRegex = /Version: v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/g
-  let versionMatch = versionRegex.exec(output)
+  const versionRegex = /Version: v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/
+  let versionMatch = output.match(versionRegex)
 
   if (versionMatch != null) return versionMatch[1]
 
   // Fallback regex to semver if versionRegex fails (protect against future changes to flow version output)
-  const fallbackRegex = /(((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?)/g
-  versionMatch ??= fallbackRegex.exec(output)
+  const fallbackRegex = /((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/
+  versionMatch ??= output.match(fallbackRegex)
   if (versionMatch != null) {
     void vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)
     return versionMatch[1]

--- a/extension/src/utils/flow-version.ts
+++ b/extension/src/utils/flow-version.ts
@@ -28,14 +28,16 @@ async function fetchFlowVersion (): Promise<semver.SemVer | null> {
 }
 
 export function extractFlowCLIVersion (buffer: Buffer | string): string | null {
-  const versionRegex = /Version: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
-  let versionMatch = versionRegex.exec(buffer.toString())
+  const output = buffer.toString()
+
+  const versionRegex = /Version: v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
+  let versionMatch = output.match(versionRegex)
 
   if (versionMatch != null) return versionMatch[1]
 
   // Fallback regex to semver if versionRegex fails (protect against future changes to flow version output)
-  const fallbackRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-  versionMatch ??= fallbackRegex.exec(buffer.toString())
+  const fallbackRegex = /^((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?$/
+  versionMatch ??= output.match(fallbackRegex)
   if (versionMatch != null) {
     void vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)
     return versionMatch[1]

--- a/extension/src/utils/flow-version.ts
+++ b/extension/src/utils/flow-version.ts
@@ -31,13 +31,13 @@ export function extractFlowCLIVersion (buffer: Buffer | string): string | null {
   const output = buffer.toString()
 
   const versionRegex = /Version: v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/g
-  let versionMatch = output.match(versionRegex)
+  let versionMatch = versionRegex.exec(output)
 
   if (versionMatch != null) return versionMatch[1]
 
   // Fallback regex to semver if versionRegex fails (protect against future changes to flow version output)
   const fallbackRegex = /(((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?)/g
-  versionMatch ??= output.match(fallbackRegex)
+  versionMatch ??= fallbackRegex.exec(output)
   if (versionMatch != null) {
     void vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)
     return versionMatch[1]

--- a/extension/src/utils/flow-version.ts
+++ b/extension/src/utils/flow-version.ts
@@ -27,7 +27,7 @@ async function fetchFlowVersion (): Promise<semver.SemVer | null> {
   }
 }
 
-export function extractFlowCLIVersion (buffer: Buffer | string): string {
+export function extractFlowCLIVersion (buffer: Buffer | string): string | null {
   const versionRegex = /Version: (0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
   let versionMatch = versionRegex.exec(buffer.toString())
 
@@ -40,6 +40,8 @@ export function extractFlowCLIVersion (buffer: Buffer | string): string {
     void vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)
     return versionMatch[1]
   }
+
+  return null
 }
 
 export const flowVersion = new StateCache(fetchFlowVersion)

--- a/extension/src/utils/flow-version.ts
+++ b/extension/src/utils/flow-version.ts
@@ -30,13 +30,13 @@ async function fetchFlowVersion (): Promise<semver.SemVer | null> {
 export function extractFlowCLIVersion (buffer: Buffer | string): string | null {
   const output = buffer.toString()
 
-  const versionRegex = /Version: v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/
+  const versionRegex = /Version: v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/g
   let versionMatch = output.match(versionRegex)
 
   if (versionMatch != null) return versionMatch[1]
 
   // Fallback regex to semver if versionRegex fails (protect against future changes to flow version output)
-  const fallbackRegex = /^((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?$/
+  const fallbackRegex = /(((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*)))?)/g
   versionMatch ??= output.match(fallbackRegex)
   if (versionMatch != null) {
     void vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)

--- a/extension/src/utils/flow-version.ts
+++ b/extension/src/utils/flow-version.ts
@@ -37,7 +37,7 @@ export function extractFlowCLIVersion (buffer: Buffer | string): string {
   const fallbackRegex = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
   versionMatch ??= fallbackRegex.exec(buffer.toString())
   if (versionMatch != null) {
-    vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)
+    void vscode.window.showWarningMessage(`Unfamiliar Flow CLI version format. Assuming that version is ${versionMatch[1]}. Please report this issue to the Flow team.`)
     return versionMatch[1]
   }
 }

--- a/extension/test/unit/parser.test.ts
+++ b/extension/test/unit/parser.test.ts
@@ -1,14 +1,24 @@
-import { parseFlowCliVersion } from '../../src/utils/flow-version'
+import { extractFlowCLIVersion } from '../../src/utils/flow-version'
 import { ASSERT_EQUAL } from '../globals'
 
 suite('Parsing Unit Tests', () => {
-  test('Flow CLI Version Parsing', async () => {
+  test('Flow CLI Version Extraction', async () => {
     let versionTest: Buffer = Buffer.from('Version: v0.1.0\nCommit: 0a1b2c3d')
-    let formatted = parseFlowCliVersion(versionTest)
+    let formatted = extractFlowCLIVersion(versionTest)
     ASSERT_EQUAL(formatted, 'v0.1.0')
 
     versionTest = Buffer.from('Version: v0.1.0')
-    formatted = parseFlowCliVersion(versionTest)
+    formatted = extractFlowCLIVersion(versionTest)
     ASSERT_EQUAL(formatted, 'v0.1.0')
+  })
+
+  test('Flow CLI Version Extraction (Fallback)', async () => {
+    let versionTest: Buffer = Buffer.from('somethingtobreak the code\nv0.1.0\nCommit: 0a1b2c3d')
+    let formatted = extractFlowCLIVersion(versionTest)
+    ASSERT_EQUAL(formatted, '0.1.0')
+
+    versionTest = Buffer.from('v0.1.0')
+    formatted = extractFlowCLIVersion(versionTest)
+    ASSERT_EQUAL(formatted, '0.1.0')
   })
 })

--- a/extension/test/unit/parser.test.ts
+++ b/extension/test/unit/parser.test.ts
@@ -5,11 +5,11 @@ suite('Parsing Unit Tests', () => {
   test('Flow CLI Version Extraction', async () => {
     let versionTest: Buffer = Buffer.from('Foobar123\nVersion: v0.1.0\nCommit: 0a1b2c3d')
     let formatted = extractFlowCLIVersion(versionTest)
-    ASSERT_EQUAL(formatted, 'v0.1.0')
+    ASSERT_EQUAL(formatted, '0.1.0')
 
     versionTest = Buffer.from('Version: v0.1.0')
     formatted = extractFlowCLIVersion(versionTest)
-    ASSERT_EQUAL(formatted, 'v0.1.0')
+    ASSERT_EQUAL(formatted, '0.1.0')
   })
 
   test('Flow CLI Version Extraction (Fallback)', async () => {

--- a/extension/test/unit/parser.test.ts
+++ b/extension/test/unit/parser.test.ts
@@ -3,7 +3,7 @@ import { ASSERT_EQUAL } from '../globals'
 
 suite('Parsing Unit Tests', () => {
   test('Flow CLI Version Extraction', async () => {
-    let versionTest: Buffer = Buffer.from('Version: v0.1.0\nCommit: 0a1b2c3d')
+    let versionTest: Buffer = Buffer.from('Foobar123\nVersion: v0.1.0\nCommit: 0a1b2c3d')
     let formatted = extractFlowCLIVersion(versionTest)
     ASSERT_EQUAL(formatted, 'v0.1.0')
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Cadence",
 	"publisher": "onflow",
 	"description": "This extension integrates Cadence, the resource-oriented smart contract programming language of Flow, into Visual Studio Code.",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/onflow/vscode-cadence.git"


### PR DESCRIPTION
relates to #509 (but was already solved on the CLI side)
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
