### PR TITLE
Use JSON `flow version` output

### DIFF
--- a/extension/src/flow-cli/cli-provider.ts
+++ b/extension/src/flow-cli/cli-provider.ts
@@ -100,7 +100,7 @@ export class CliProvider {
       ))).stdout
 
       // Format version string from output
-      let versionInfo: FlowVersionOutput = JSON.parse(buffer)
+      const versionInfo: FlowVersionOutput = JSON.parse(buffer)
 
       // Ensure user has a compatible version number installed
       const version: semver.SemVer | null = semver.parse(versionInfo.version)
@@ -109,8 +109,7 @@ export class CliProvider {
       return { name: bin, version }
     } catch {
       // Fallback to old method if JSON is not supported/fails
-      console.warn(`Failed to fetch binary version information for "${bin}", falling back to old method`)
-      return this.#fetchBinaryInformationOld(bin)
+      return await this.#fetchBinaryInformationOld(bin)
     }
   }
 

--- a/extension/src/flow-cli/cli-provider.ts
+++ b/extension/src/flow-cli/cli-provider.ts
@@ -6,7 +6,9 @@ import * as vscode from 'vscode'
 import { Settings } from '../settings/settings'
 import { isEqual } from 'lodash'
 
-const CHECK_FLOW_CLI_CMD = (flowCommand: string): string => `${flowCommand} version`
+const CHECK_FLOW_CLI_CMD = (flowCommand: string): string => `${flowCommand} version --output=json`
+const CHECK_FLOW_CLI_CMD_NO_JSON = (flowCommand: string): string => `${flowCommand} version`
+
 const KNOWN_BINS = ['flow', 'flow-c1']
 
 const CADENCE_V1_CLI_REGEX = /-cadence-v1.0.0/g
@@ -14,6 +16,10 @@ const CADENCE_V1_CLI_REGEX = /-cadence-v1.0.0/g
 export interface CliBinary {
   name: string
   version: semver.SemVer
+}
+
+interface FlowVersionOutput {
+  version: string
 }
 
 interface AvailableBinariesCache {
@@ -85,10 +91,35 @@ export class CliProvider {
     })
   }
 
+  // Fetches the binary information for the given binary
   async #fetchBinaryInformation (bin: string): Promise<CliBinary | null> {
     try {
       // Get user's version informaton
       const buffer: string = (await execDefault(CHECK_FLOW_CLI_CMD(
+        bin
+      ))).stdout
+
+      // Format version string from output
+      let versionInfo: FlowVersionOutput = JSON.parse(buffer)
+
+      // Ensure user has a compatible version number installed
+      const version: semver.SemVer | null = semver.parse(versionInfo.version)
+      if (version === null) return null
+
+      return { name: bin, version }
+    } catch {
+      // Fallback to old method if JSON is not supported/fails
+      console.warn(`Failed to fetch binary version information for "${bin}", falling back to old method`)
+      return this.#fetchBinaryInformationOld(bin)
+    }
+  }
+
+  // Old version of fetchBinaryInformation (before JSON was supported)
+  // Used as fallback for old CLI versions
+  async #fetchBinaryInformationOld (bin: string): Promise<CliBinary | null> {
+    try {
+      // Get user's version informaton
+      const buffer: string = (await execDefault(CHECK_FLOW_CLI_CMD_NO_JSON(
         bin
       ))).stdout
 


### PR DESCRIPTION
Closes #564 

## Description

Use new JSON output and fallback to old method

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
