### PR TITLE
Refactor CLI version selection

### DIFF
--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -6,7 +6,7 @@ import { Installer, InstallerConstructor, InstallerContext } from '../installer'
 import * as semver from 'semver'
 import fetch from 'node-fetch'
 import { HomebrewInstaller } from './homebrew-installer'
-import { KNOWN_FLOW_COMMANDS } from '../../flow-cli/binary-versions-provider'
+import { KNOWN_FLOW_COMMANDS } from '../../flow-cli/cli-versions-provider'
 
 // Command to check flow-cli
 const COMPATIBLE_FLOW_CLI_VERSIONS = '>=1.6.0'

--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -128,7 +128,10 @@ export class InstallFlowCLI extends Installer {
   async verifyInstall (): Promise<boolean> {
     // Check if flow version is valid to verify install
     this.#context.cliProvider.refresh()
-    const installedVersions = await this.#context.cliProvider.getBinaryVersions()
+    const installedVersions = await this.#context.cliProvider.getBinaryVersions().catch((e) => {
+      window.showErrorMessage('Failed to check CLI version: ' + e.message)
+      return []
+    })
     const version = installedVersions.find(y => y.command === KNOWN_FLOW_COMMANDS.DEFAULT)?.version
     if (version == null) return false
 

--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -6,6 +6,7 @@ import { Installer, InstallerConstructor, InstallerContext } from '../installer'
 import * as semver from 'semver'
 import fetch from 'node-fetch'
 import { HomebrewInstaller } from './homebrew-installer'
+import { KNOWN_FLOW_COMMANDS } from '../../flow-cli/binary-versions-provider'
 
 // Command to check flow-cli
 const COMPATIBLE_FLOW_CLI_VERSIONS = '>=1.6.0'
@@ -97,10 +98,10 @@ export class InstallFlowCLI extends Installer {
     }
   }
 
-  async checkVersion (vsn?: semver.SemVer): Promise<boolean> {
+  async checkVersion (vsn: semver.SemVer): Promise<boolean> {
     // Get user's version informaton
     this.#context.cliProvider.refresh()
-    const version = vsn ?? await this.#context.cliProvider.getBinaryVersions().then(x => x.find(y => y.path === 'flow')?.version)
+    const version = vsn
     if (version == null) return false
 
     if (!semver.satisfies(version, COMPATIBLE_FLOW_CLI_VERSIONS, {
@@ -128,7 +129,8 @@ export class InstallFlowCLI extends Installer {
   async verifyInstall (): Promise<boolean> {
     // Check if flow version is valid to verify install
     this.#context.cliProvider.refresh()
-    const version = await this.#context.cliProvider.getBinaryVersions().then(x => x.find(y => y.path === 'flow')?.version)
+    const installedVersions = await this.#context.cliProvider.getBinaryVersions()
+    const version = installedVersions.find(y => y.command === KNOWN_FLOW_COMMANDS.DEFAULT)?.version
     if (version == null) return false
 
     // Check flow-cli version number

--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -98,10 +98,9 @@ export class InstallFlowCLI extends Installer {
     }
   }
 
-  async checkVersion (vsn: semver.SemVer): Promise<boolean> {
+  async checkVersion (version: semver.SemVer): Promise<boolean> {
     // Get user's version informaton
     this.#context.cliProvider.refresh()
-    const version = vsn
     if (version == null) return false
 
     if (!semver.satisfies(version, COMPATIBLE_FLOW_CLI_VERSIONS, {

--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -129,7 +129,7 @@ export class InstallFlowCLI extends Installer {
     // Check if flow version is valid to verify install
     this.#context.cliProvider.refresh()
     const installedVersions = await this.#context.cliProvider.getBinaryVersions().catch((e) => {
-      window.showErrorMessage('Failed to check CLI version: ' + e.message)
+      void window.showErrorMessage(`Failed to check CLI version: ${String(e.message)}`)
       return []
     })
     const version = installedVersions.find(y => y.command === KNOWN_FLOW_COMMANDS.DEFAULT)?.version

--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -100,7 +100,7 @@ export class InstallFlowCLI extends Installer {
   async checkVersion (vsn?: semver.SemVer): Promise<boolean> {
     // Get user's version informaton
     this.#context.cliProvider.refresh()
-    const version = vsn ?? await this.#context.cliProvider.getAvailableBinaries().then(x => x.find(y => y.name === 'flow')?.version)
+    const version = vsn ?? await this.#context.cliProvider.getBinaryVersions().then(x => x.find(y => y.path === 'flow')?.version)
     if (version == null) return false
 
     if (!semver.satisfies(version, COMPATIBLE_FLOW_CLI_VERSIONS, {
@@ -128,7 +128,7 @@ export class InstallFlowCLI extends Installer {
   async verifyInstall (): Promise<boolean> {
     // Check if flow version is valid to verify install
     this.#context.cliProvider.refresh()
-    const version = await this.#context.cliProvider.getAvailableBinaries().then(x => x.find(y => y.name === 'flow')?.version)
+    const version = await this.#context.cliProvider.getBinaryVersions().then(x => x.find(y => y.path === 'flow')?.version)
     if (version == null) return false
 
     // Check flow-cli version number

--- a/extension/src/flow-cli/binary-versions-provider.ts
+++ b/extension/src/flow-cli/binary-versions-provider.ts
@@ -12,6 +12,8 @@ export enum KNOWN_FLOW_COMMANDS {
   CADENCE_V1 = 'flow-c1',
 }
 
+// This regex matches a string like "Version: v{SEMVER}" and extracts the version number
+// It uses the official semver regex from https://semver.org/
 const LEGACY_VERSION_REGEXP = /Version:\s*(v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(\s|$)/m
 
 export interface CliBinary {

--- a/extension/src/flow-cli/binary-versions-provider.ts
+++ b/extension/src/flow-cli/binary-versions-provider.ts
@@ -52,20 +52,20 @@ export class BinaryVersionsProvider {
     })
   }
 
-  add (path: string): void {
-    if (this.#caches[path] != null) return
-    this.#caches[path] = new StateCache(async () => await this.#fetchBinaryInformation(path))
-    this.#caches[path].subscribe(() => {
+  add (command: string): void {
+    if (this.#caches[command] != null) return
+    this.#caches[command] = new StateCache(async () => await this.#fetchBinaryInformation(command))
+    this.#caches[command].subscribe(() => {
       this.#rootCache?.invalidate()
     })
     this.#rootCache?.invalidate()
   }
 
-  remove (path: string): void {
+  remove (command: string): void {
     // Known binaries cannot be removed
-    if (this.#caches[path] == null || (Object.values(KNOWN_FLOW_COMMANDS) as string[]).includes(path)) return
+    if (this.#caches[command] == null || (Object.values(KNOWN_FLOW_COMMANDS) as string[]).includes(command)) return
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete this.#caches[path]
+    delete this.#caches[command]
     this.#rootCache?.invalidate()
   }
 

--- a/extension/src/flow-cli/binary-versions-provider.ts
+++ b/extension/src/flow-cli/binary-versions-provider.ts
@@ -1,0 +1,141 @@
+import * as semver from 'semver'
+import { StateCache } from '../utils/state-cache'
+import { execDefault } from '../utils/shell/exec'
+import { Observable, distinctUntilChanged } from 'rxjs'
+import { isEqual } from 'lodash'
+
+const CHECK_FLOW_CLI_CMD = (flowCommand: string): string => `${flowCommand} version --output=json`
+const CHECK_FLOW_CLI_CMD_NO_JSON = (flowCommand: string): string => `${flowCommand} version`
+
+const KNOWN_BINS = ['flow', 'flow-c1']
+
+const LEGACY_VERSION_REGEXP = /Version:\s*(v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(\s|$)/m
+
+export interface CliBinary {
+  path: string
+  version: semver.SemVer
+}
+
+interface FlowVersionOutput {
+  version: string
+}
+
+export class BinaryVersionsProvider {
+  #rootCache: StateCache<CliBinary[]>
+  #caches: { [key: string]: StateCache<CliBinary | null> } = {}
+
+  constructor (seedBinaries: string[] = []) {
+    // Seed the caches with the known binaries
+    KNOWN_BINS.forEach((bin) => {
+      this.add(bin)
+    })
+
+    // Seed the caches with any additional binaries
+    seedBinaries.forEach((bin) => {
+      this.add(bin)
+    })
+
+    // Create the root cache. This cache will hold all the binary information
+    // and is a combination of all the individual caches for each binary
+    this.#rootCache = new StateCache(async () => {
+      const binaries = await Promise.all(
+        Object.keys(this.#caches).map(async (bin) => {
+          return await this.#caches[bin].getValue().catch(() => null)
+        })
+      )
+
+      // Filter out missing binaries
+      return binaries.filter((bin) => bin != null) as CliBinary[]
+    })
+  }
+
+  add (path: string): void {
+    if (this.#caches[path] != null) return
+    this.#caches[path] = new StateCache(async () => await this.#fetchBinaryInformation(path))
+    this.#caches[path].subscribe(() => {
+      this.#rootCache?.invalidate()
+    })
+    this.#rootCache?.invalidate()
+  }
+
+  remove (path: string): void {
+    // Known binaries cannot be removed
+    if (this.#caches[path] == null || KNOWN_BINS.includes(path)) return
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete this.#caches[path]
+    this.#rootCache?.invalidate()
+  }
+
+  get (name: string): StateCache<CliBinary | null> | null {
+    return this.#caches[name] ?? null
+  }
+
+  // Fetches the binary information for the given binary
+  async #fetchBinaryInformation (bin: string): Promise<CliBinary | null> {
+    try {
+      // Get user's version informaton
+      const buffer: string = (await execDefault(CHECK_FLOW_CLI_CMD(
+        bin
+      ))).stdout
+
+      // Format version string from output
+      const versionInfo: FlowVersionOutput = JSON.parse(buffer)
+
+      // Ensure user has a compatible version number installed
+      const version: semver.SemVer | null = semver.parse(versionInfo.version)
+      if (version === null) return null
+
+      return { path: bin, version }
+    } catch {
+      // Fallback to old method if JSON is not supported/fails
+      return await this.#fetchBinaryInformationOld(bin)
+    }
+  }
+
+  // Old version of fetchBinaryInformation (before JSON was supported)
+  // Used as fallback for old CLI versions
+  async #fetchBinaryInformationOld (bin: string): Promise<CliBinary | null> {
+    try {
+      // Get user's version informaton
+      const output = (await execDefault(CHECK_FLOW_CLI_CMD_NO_JSON(
+        bin
+      )))
+
+      let versionStr: string | null = parseFlowCliVersion(output.stdout)
+      if (versionStr === null) {
+        // Try to fallback to stderr as patch for bugged version
+        versionStr = parseFlowCliVersion(output.stderr)
+      }
+
+      versionStr = versionStr != null ? semver.clean(versionStr) : null
+      if (versionStr === null) return null
+
+      // Ensure user has a compatible version number installed
+      const version: semver.SemVer | null = semver.parse(versionStr)
+      if (version === null) return null
+
+      return { path: bin, version }
+    } catch {
+      return null
+    }
+  }
+
+  refresh (): void {
+    Object.keys(this.#caches).forEach((bin) => {
+      this.#caches[bin].invalidate()
+    })
+    this.#rootCache.invalidate()
+  }
+
+  async getVersions (): Promise<CliBinary[]> {
+    return await this.#rootCache.getValue()
+  }
+
+  get versions$ (): Observable<CliBinary[]> {
+    return this.#rootCache.pipe(distinctUntilChanged(isEqual))
+  }
+}
+
+export function parseFlowCliVersion (buffer: Buffer | string): string | null {
+  return buffer.toString().match(LEGACY_VERSION_REGEXP)?.[1] ?? null
+}

--- a/extension/src/flow-cli/cli-provider.ts
+++ b/extension/src/flow-cli/cli-provider.ts
@@ -3,7 +3,7 @@ import { StateCache } from '../utils/state-cache'
 import * as vscode from 'vscode'
 import { Settings } from '../settings/settings'
 import { isEqual } from 'lodash'
-import { CliBinary, BinaryVersionsProvider } from './binary-versions-provider'
+import { CliBinary, BinaryVersionsProvider, KNOWN_FLOW_COMMANDS } from './binary-versions-provider'
 
 export class CliProvider {
   #selectedBinaryName: BehaviorSubject<string>
@@ -31,7 +31,7 @@ export class CliProvider {
 
     // Display warning to user if binary doesn't exist (only if not using the default binary)
     this.currentBinary$.subscribe((binary) => {
-      if (binary === null && this.#selectedBinaryName.getValue() !== 'flow') {
+      if (binary === null && this.#selectedBinaryName.getValue() !== KNOWN_FLOW_COMMANDS.DEFAULT) {
         void vscode.window.showErrorMessage(`The configured Flow CLI binary "${this.#selectedBinaryName.getValue()}" does not exist. Please check your settings.`)
       }
     })

--- a/extension/src/flow-cli/cli-provider.ts
+++ b/extension/src/flow-cli/cli-provider.ts
@@ -1,66 +1,36 @@
 import { BehaviorSubject, Observable, distinctUntilChanged, pairwise, startWith } from 'rxjs'
-import { execDefault } from '../utils/shell/exec'
 import { StateCache } from '../utils/state-cache'
-import * as semver from 'semver'
 import * as vscode from 'vscode'
 import { Settings } from '../settings/settings'
 import { isEqual } from 'lodash'
-
-const CHECK_FLOW_CLI_CMD = (flowCommand: string): string => `${flowCommand} version --output=json`
-const CHECK_FLOW_CLI_CMD_NO_JSON = (flowCommand: string): string => `${flowCommand} version`
-
-const KNOWN_BINS = ['flow', 'flow-c1']
-
-const CADENCE_V1_CLI_REGEX = /-cadence-v1.0.0/g
-const LEGACY_VERSION_REGEXP = /Version:\s*(v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(\s|$)/m
-
-export interface CliBinary {
-  name: string
-  version: semver.SemVer
-}
-
-interface FlowVersionOutput {
-  version: string
-}
-
-interface AvailableBinariesCache {
-  [key: string]: StateCache<CliBinary | null>
-}
+import { CliBinary, BinaryVersionsProvider } from './binary-versions-provider'
 
 export class CliProvider {
   #selectedBinaryName: BehaviorSubject<string>
   #currentBinary$: StateCache<CliBinary | null>
-  #availableBinaries: AvailableBinariesCache = {}
-  #availableBinaries$: StateCache<CliBinary[]>
+  #binaryVersions: BinaryVersionsProvider
   #settings: Settings
 
   constructor (settings: Settings) {
-    this.#settings = settings
+    const initialBinaryPath = settings.getSettings().flowCommand
 
-    this.#selectedBinaryName = new BehaviorSubject<string>(settings.getSettings().flowCommand)
+    this.#settings = settings
+    this.#binaryVersions = new BinaryVersionsProvider([initialBinaryPath])
+    this.#selectedBinaryName = new BehaviorSubject<string>(initialBinaryPath)
+    this.#currentBinary$ = new StateCache(async () => {
+      const name: string = this.#selectedBinaryName.getValue()
+      const versionCache = this.#binaryVersions.get(name)
+      if (versionCache == null) return null
+      return await versionCache.getValue()
+    })
+
+    // Bind the selected binary to the settings
     this.#settings.watch$(config => config.flowCommand).subscribe((flowCommand) => {
       this.#selectedBinaryName.next(flowCommand)
     })
 
-    this.#availableBinaries = KNOWN_BINS.reduce<AvailableBinariesCache>((acc, bin) => {
-      acc[bin] = new StateCache(async () => await this.#fetchBinaryInformation(bin))
-      acc[bin].subscribe(() => {
-        this.#availableBinaries$.invalidate()
-      })
-      return acc
-    }, {})
-
-    this.#availableBinaries$ = new StateCache(async () => {
-      return await this.getAvailableBinaries()
-    })
-
-    this.#currentBinary$ = new StateCache(async () => {
-      const name: string = this.#selectedBinaryName.getValue()
-      return await this.#availableBinaries[name].getValue()
-    })
-
     // Display warning to user if binary doesn't exist (only if not using the default binary)
-    this.#currentBinary$.subscribe((binary) => {
+    this.currentBinary$.subscribe((binary) => {
       if (binary === null && this.#selectedBinaryName.getValue() !== 'flow') {
         void vscode.window.showErrorMessage(`The configured Flow CLI binary "${this.#selectedBinaryName.getValue()}" does not exist. Please check your settings.`)
       }
@@ -72,104 +42,15 @@ export class CliProvider {
   #watchForBinaryChanges (): void {
     // Subscribe to changes in the selected binary to update the caches
     this.#selectedBinaryName.pipe(distinctUntilChanged(), startWith(null), pairwise()).subscribe(([prev, curr]) => {
-      // Swap out the cache for the selected binary
-      if (prev != null && !KNOWN_BINS.includes(prev)) {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete this.#availableBinaries[prev]
-      }
-      if (curr != null && !KNOWN_BINS.includes(curr)) {
-        this.#availableBinaries[curr] = new StateCache(async () => await this.#fetchBinaryInformation(curr))
-        this.#availableBinaries[curr].subscribe(() => {
-          this.#availableBinaries$.invalidate()
-        })
-      }
+      // Remove the previous binary from the cache
+      if (prev != null) this.#binaryVersions.remove(prev)
+
+      // Add the current binary to the cache
+      if (curr != null) this.#binaryVersions.add(curr)
 
       // Invalidate the current binary cache
       this.#currentBinary$.invalidate()
-
-      // Invalidate the available binaries cache
-      this.#availableBinaries$.invalidate()
     })
-  }
-
-  // Fetches the binary information for the given binary
-  async #fetchBinaryInformation (bin: string): Promise<CliBinary | null> {
-    try {
-      // Get user's version informaton
-      const buffer: string = (await execDefault(CHECK_FLOW_CLI_CMD(
-        bin
-      ))).stdout
-
-      // Format version string from output
-      const versionInfo: FlowVersionOutput = JSON.parse(buffer)
-
-      // Ensure user has a compatible version number installed
-      const version: semver.SemVer | null = semver.parse(versionInfo.version)
-      if (version === null) return null
-
-      return { name: bin, version }
-    } catch {
-      // Fallback to old method if JSON is not supported/fails
-      return await this.#fetchBinaryInformationOld(bin)
-    }
-  }
-
-  // Old version of fetchBinaryInformation (before JSON was supported)
-  // Used as fallback for old CLI versions
-  async #fetchBinaryInformationOld (bin: string): Promise<CliBinary | null> {
-    try {
-      // Get user's version informaton
-      const output = (await execDefault(CHECK_FLOW_CLI_CMD_NO_JSON(
-        bin
-      )))
-
-      let versionStr: string | null = parseFlowCliVersion(output.stdout)
-      if (versionStr === null) {
-        // Try to fallback to stderr as patch for bugged version
-        versionStr = parseFlowCliVersion(output.stderr)
-      }
-
-      versionStr = versionStr != null ? semver.clean(versionStr) : null
-      if (versionStr === null) return null
-
-      // Ensure user has a compatible version number installed
-      const version: semver.SemVer | null = semver.parse(versionStr)
-      if (version === null) return null
-
-      return { name: bin, version }
-    } catch {
-      return null
-    }
-  }
-
-  refresh (): void {
-    for (const bin in this.#availableBinaries) {
-      this.#availableBinaries[bin].invalidate()
-    }
-    this.#currentBinary$.invalidate()
-  }
-
-  get availableBinaries$ (): Observable<CliBinary[]> {
-    return new Observable((subscriber) => {
-      this.#availableBinaries$.subscribe((binaries) => {
-        subscriber.next(binaries)
-      })
-    }).pipe(distinctUntilChanged(isEqual))
-  }
-
-  async getAvailableBinaries (): Promise<CliBinary[]> {
-    const bins: CliBinary[] = []
-    for (const name in this.#availableBinaries) {
-      const binary = await this.#availableBinaries[name].getValue().catch(() => null)
-      if (binary !== null) {
-        bins.push(binary)
-      }
-    }
-    return bins
-  }
-
-  get currentBinary$ (): Observable<CliBinary | null> {
-    return this.#currentBinary$.pipe(distinctUntilChanged(isEqual))
   }
 
   async getCurrentBinary (): Promise<CliBinary | null> {
@@ -179,12 +60,21 @@ export class CliProvider {
   async setCurrentBinary (name: string): Promise<void> {
     await this.#settings.updateSettings({ flowCommand: name })
   }
-}
 
-export function isCadenceV1Cli (version: semver.SemVer): boolean {
-  return CADENCE_V1_CLI_REGEX.test(version.raw)
-}
+  get currentBinary$ (): Observable<CliBinary | null> {
+    return this.#currentBinary$.pipe(distinctUntilChanged(isEqual))
+  }
 
-export function parseFlowCliVersion (buffer: Buffer | string): string | null {
-  return buffer.toString().match(LEGACY_VERSION_REGEXP)?.[1] ?? null
+  async getBinaryVersions (): Promise<CliBinary[]> {
+    return await this.#binaryVersions.getVersions()
+  }
+
+  get binaryVersions$ (): Observable<CliBinary[]> {
+    return this.#binaryVersions.versions$.pipe(distinctUntilChanged(isEqual))
+  }
+
+  // Refresh all cached binary versions
+  refresh (): void {
+    this.#binaryVersions.refresh()
+  }
 }

--- a/extension/src/flow-cli/cli-selection-provider.ts
+++ b/extension/src/flow-cli/cli-selection-provider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import { zip } from 'rxjs'
 import { CliProvider } from './cli-provider'
 import { SemVer } from 'semver'
-import { CliBinary } from './binary-versions-provider'
+import { CliBinary } from './cli-versions-provider'
 
 const CHANGE_CLI_BINARY = 'cadence.changeFlowCliBinary'
 const CADENCE_V1_CLI_REGEX = /-cadence-v1.0.0/g

--- a/extension/src/flow-cli/cli-selection-provider.ts
+++ b/extension/src/flow-cli/cli-selection-provider.ts
@@ -79,6 +79,10 @@ export class CliSelectionProvider {
       }
     }))
 
+    this.#disposables.push(versionSelector.onDidHide(() => {
+      void this.#toggleSelector(false)
+    }))
+
     // Update available versions
     const items: Array<AvailableBinaryItem | CustomBinaryItem> = availableBinaries.map(binary => new AvailableBinaryItem(binary))
     items.push(new CustomBinaryItem())

--- a/extension/src/flow-cli/cli-selection-provider.ts
+++ b/extension/src/flow-cli/cli-selection-provider.ts
@@ -75,7 +75,7 @@ export class CliSelectionProvider {
           }
         })
       } else if (selected instanceof AvailableBinaryItem) {
-        void this.#cliProvider.setCurrentBinary(selected.path)
+        void this.#cliProvider.setCurrentBinary(selected.command)
       }
     }))
 
@@ -84,7 +84,7 @@ export class CliSelectionProvider {
     items.push(new CustomBinaryItem())
 
     // Hoist the current binary to the top of the list
-    const currentBinaryIndex = items.findIndex(item => item instanceof AvailableBinaryItem && item.path === currentBinary?.path)
+    const currentBinaryIndex = items.findIndex(item => item instanceof AvailableBinaryItem && item.command === currentBinary?.command)
     if (currentBinaryIndex != null) {
       const currentBinaryItem = items[currentBinaryIndex]
       items.splice(currentBinaryIndex, 1)
@@ -135,11 +135,11 @@ class AvailableBinaryItem implements vscode.QuickPickItem {
   }
 
   get description (): string {
-    return `(${this.#binary.path})`
+    return `(${this.#binary.command})`
   }
 
-  get path (): string {
-    return this.#binary.path
+  get command (): string {
+    return this.#binary.command
   }
 }
 

--- a/extension/src/flow-cli/cli-selection-provider.ts
+++ b/extension/src/flow-cli/cli-selection-provider.ts
@@ -82,16 +82,16 @@ export class CliSelectionProvider {
     // Update available versions
     const items: Array<AvailableBinaryItem | CustomBinaryItem> = availableBinaries.map(binary => new AvailableBinaryItem(binary))
     items.push(new CustomBinaryItem())
-    versionSelector.items = items
 
-    // Select the current binary
-    if (currentBinary !== null) {
-      const currentBinaryItem = versionSelector.items.find(item => item instanceof AvailableBinaryItem && item.path === currentBinary.path)
-      if (currentBinaryItem != null) {
-        versionSelector.selectedItems = [currentBinaryItem]
-      }
+    // Hoist the current binary to the top of the list
+    const currentBinaryIndex = items.findIndex(item => item instanceof AvailableBinaryItem && item.path === currentBinary?.path)
+    if (currentBinaryIndex != null) {
+      const currentBinaryItem = items[currentBinaryIndex]
+      items.splice(currentBinaryIndex, 1)
+      items.unshift(currentBinaryItem)
     }
 
+    versionSelector.items = items
     return versionSelector
   }
 

--- a/extension/src/flow-cli/cli-selection-provider.ts
+++ b/extension/src/flow-cli/cli-selection-provider.ts
@@ -84,8 +84,12 @@ export class CliSelectionProvider {
     items.push(new CustomBinaryItem())
 
     // Hoist the current binary to the top of the list
-    const currentBinaryIndex = items.findIndex(item => item instanceof AvailableBinaryItem && item.command === currentBinary?.command)
-    if (currentBinaryIndex != null) {
+    const currentBinaryIndex = items.findIndex(item =>
+      item instanceof AvailableBinaryItem &&
+      currentBinary != null &&
+      item.command === currentBinary.command
+    )
+    if (currentBinaryIndex !== -1) {
       const currentBinaryItem = items[currentBinaryIndex]
       items.splice(currentBinaryIndex, 1)
       items.unshift(currentBinaryItem)

--- a/extension/src/flow-cli/cli-versions-provider.ts
+++ b/extension/src/flow-cli/cli-versions-provider.ts
@@ -25,7 +25,7 @@ interface FlowVersionOutput {
   version: string
 }
 
-export class BinaryVersionsProvider {
+export class CliVersionsProvider {
   #rootCache: StateCache<CliBinary[]>
   #caches: { [key: string]: StateCache<CliBinary | null> } = {}
 

--- a/extension/src/flow-cli/cli-versions-provider.ts
+++ b/extension/src/flow-cli/cli-versions-provider.ts
@@ -85,11 +85,7 @@ export class CliVersionsProvider {
       // Format version string from output
       const versionInfo: FlowVersionOutput = JSON.parse(buffer)
 
-      // Ensure user has a compatible version number installed
-      const version: semver.SemVer | null = semver.parse(versionInfo.version)
-      if (version === null) return null
-
-      return { command: bin, version }
+      return cliBinaryFromVersion(bin, versionInfo.version)
     } catch {
       // Fallback to old method if JSON is not supported/fails
       return await this.#fetchBinaryInformationOld(bin)
@@ -111,11 +107,9 @@ export class CliVersionsProvider {
         versionStr = parseFlowCliVersion(output.stderr)
       }
 
-      // Ensure user has a compatible version number installed
-      const version: semver.SemVer | null = semver.parse(versionStr)
-      if (version === null) return null
+      if (versionStr == null) return null
 
-      return { command: bin, version }
+      return cliBinaryFromVersion(bin, versionStr)
     } catch {
       return null
     }
@@ -141,4 +135,12 @@ export function parseFlowCliVersion (buffer: Buffer | string): string | null {
   const rawMatch = buffer.toString().match(LEGACY_VERSION_REGEXP)?.[1] ?? null
   if (rawMatch == null) return null
   return semver.clean(rawMatch)
+}
+
+function cliBinaryFromVersion (bin: string, versionStr: string): CliBinary | null {
+  // Ensure user has a compatible version number installed
+  const version: semver.SemVer | null = semver.parse(versionStr)
+  if (version === null) return null
+
+  return { command: bin, version }
 }

--- a/extension/src/flow-cli/cli-versions-provider.ts
+++ b/extension/src/flow-cli/cli-versions-provider.ts
@@ -13,7 +13,7 @@ export enum KNOWN_FLOW_COMMANDS {
 }
 
 // Matches the version number from the output of the Flow CLI
-const LEGACY_VERSION_REGEXP = /Version:\s*v(.*)(?\s|$)/m
+const LEGACY_VERSION_REGEXP = /Version:\s*v(.*)(?:\s|$)/m
 
 export interface CliBinary {
   command: string

--- a/extension/src/server/language-server.ts
+++ b/extension/src/server/language-server.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject, Subscription, filter, firstValueFrom, skip } from 'rxj
 import { envVars } from '../utils/shell/env-vars'
 import { FlowConfig } from './flow-config'
 import { CliProvider } from '../flow-cli/cli-provider'
+import { KNOWN_FLOW_COMMANDS } from '../flow-cli/binary-versions-provider'
 
 // Identities for commands handled by the Language server
 const RELOAD_CONFIGURATION = 'cadence.server.flow.reloadConfiguration'
@@ -75,12 +76,12 @@ export class LanguageServerAPI {
       const accessCheckMode: string = this.#settings.getSettings().accessCheckMode
       const configPath: string | null = this.#config.configPath
 
-      const binaryPath = (await this.#cliProvider.getCurrentBinary())?.path
+      const binaryPath = (await this.#cliProvider.getCurrentBinary())?.command
       if (binaryPath == null) {
         throw new Error('No flow binary found')
       }
 
-      if (binaryPath !== 'flow') {
+      if (binaryPath !== KNOWN_FLOW_COMMANDS.DEFAULT) {
         try {
           exec('killall dlv') // Required when running language server locally on mac
         } catch (err) { void err }

--- a/extension/src/server/language-server.ts
+++ b/extension/src/server/language-server.ts
@@ -75,7 +75,7 @@ export class LanguageServerAPI {
       const accessCheckMode: string = this.#settings.getSettings().accessCheckMode
       const configPath: string | null = this.#config.configPath
 
-      const binaryPath = (await this.#cliProvider.getCurrentBinary())?.name
+      const binaryPath = (await this.#cliProvider.getCurrentBinary())?.path
       if (binaryPath == null) {
         throw new Error('No flow binary found')
       }

--- a/extension/src/server/language-server.ts
+++ b/extension/src/server/language-server.ts
@@ -7,7 +7,7 @@ import { BehaviorSubject, Subscription, filter, firstValueFrom, skip } from 'rxj
 import { envVars } from '../utils/shell/env-vars'
 import { FlowConfig } from './flow-config'
 import { CliProvider } from '../flow-cli/cli-provider'
-import { KNOWN_FLOW_COMMANDS } from '../flow-cli/binary-versions-provider'
+import { KNOWN_FLOW_COMMANDS } from '../flow-cli/cli-versions-provider'
 
 // Identities for commands handled by the Language server
 const RELOAD_CONFIGURATION = 'cadence.server.flow.reloadConfiguration'

--- a/extension/test/integration/1 - language-server.test.ts
+++ b/extension/test/integration/1 - language-server.test.ts
@@ -9,7 +9,7 @@ import { BehaviorSubject, Subject } from 'rxjs'
 import { State } from 'vscode-languageclient'
 import * as sinon from 'sinon'
 import { SemVer } from 'semver'
-import { CliBinary } from '../../src/flow-cli/binary-versions-provider'
+import { CliBinary } from '../../src/flow-cli/cli-versions-provider'
 
 suite('Language Server & Emulator Integration', () => {
   let LS: LanguageServerAPI

--- a/extension/test/integration/1 - language-server.test.ts
+++ b/extension/test/integration/1 - language-server.test.ts
@@ -8,8 +8,8 @@ import { MaxTimeout } from '../globals'
 import { BehaviorSubject, Subject } from 'rxjs'
 import { State } from 'vscode-languageclient'
 import * as sinon from 'sinon'
-import { CliBinary } from '../../src/flow-cli/cli-provider'
 import { SemVer } from 'semver'
+import { CliBinary } from '../../src/flow-cli/binary-versions-provider'
 
 suite('Language Server & Emulator Integration', () => {
   let LS: LanguageServerAPI
@@ -33,7 +33,7 @@ suite('Language Server & Emulator Integration', () => {
 
     // create a mock cli provider without invokign the constructor
     cliBinary$ = new BehaviorSubject<CliBinary>({
-      name: 'flow',
+      path: 'flow',
       version: new SemVer('1.0.0')
     })
     const mockCliProvider = {
@@ -63,7 +63,7 @@ suite('Language Server & Emulator Integration', () => {
     fileModified$.next()
     pathChanged$.next('foo')
     cliBinary$.next({
-      name: 'flow',
+      path: 'flow',
       version: new SemVer('1.0.1')
     })
 

--- a/extension/test/integration/1 - language-server.test.ts
+++ b/extension/test/integration/1 - language-server.test.ts
@@ -33,7 +33,7 @@ suite('Language Server & Emulator Integration', () => {
 
     // create a mock cli provider without invokign the constructor
     cliBinary$ = new BehaviorSubject<CliBinary>({
-      path: 'flow',
+      command: 'flow',
       version: new SemVer('1.0.0')
     })
     const mockCliProvider = {
@@ -63,7 +63,7 @@ suite('Language Server & Emulator Integration', () => {
     fileModified$.next()
     pathChanged$.next('foo')
     cliBinary$.next({
-      path: 'flow',
+      command: 'flow',
       version: new SemVer('1.0.1')
     })
 

--- a/extension/test/unit/parser.test.ts
+++ b/extension/test/unit/parser.test.ts
@@ -8,17 +8,17 @@ suite('Parsing Unit Tests', () => {
   test('Flow CLI Version Parsing (buffer input)', async () => {
     let versionTest: Buffer = Buffer.from('Version: v0.1.0\nCommit: 0a1b2c3d')
     let formatted = parseFlowCliVersion(versionTest)
-    ASSERT_EQUAL(formatted, 'v0.1.0')
+    ASSERT_EQUAL(formatted, '0.1.0')
 
     versionTest = Buffer.from('Version: v0.1.0')
     formatted = parseFlowCliVersion(versionTest)
-    ASSERT_EQUAL(formatted, 'v0.1.0')
+    ASSERT_EQUAL(formatted, '0.1.0')
   })
 
   test('Flow CLI Version Parsing (string input)', async () => {
     const versionTest: string = 'Version: v0.1.0\nCommit: 0a1b2c3d'
     const formatted = parseFlowCliVersion(versionTest)
-    ASSERT_EQUAL(formatted, 'v0.1.0')
+    ASSERT_EQUAL(formatted, '0.1.0')
   })
 
   test('Flow CLI Version Parsing produces valid semver from Flow CLI output', async () => {

--- a/extension/test/unit/parser.test.ts
+++ b/extension/test/unit/parser.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { parseFlowCliVersion } from '../../src/flow-cli/cli-provider'
+import { parseFlowCliVersion } from '../../src/flow-cli/binary-versions-provider'
 import { execDefault } from '../../src/utils/shell/exec'
 import { ASSERT_EQUAL } from '../globals'
 import * as semver from 'semver'

--- a/extension/test/unit/parser.test.ts
+++ b/extension/test/unit/parser.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import { parseFlowCliVersion } from '../../src/flow-cli/binary-versions-provider'
+import { parseFlowCliVersion } from '../../src/flow-cli/cli-versions-provider'
 import { execDefault } from '../../src/utils/shell/exec'
 import { ASSERT_EQUAL } from '../globals'
 import * as semver from 'semver'

--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
 				"title": "Check Dependencies"
 			},
 			{
-				"command": "cadence.changeCadenceVersion",
+				"command": "cadence.changeFlowCliBinary",
 				"category": "Cadence",
-				"title": "Change Cadence Version"
+				"title": "Change Flow CLI Binary"
 			}
 		],
 		"configuration": {


### PR DESCRIPTION
Closes #575 
Closes #583 

## Description

The code was maybe a bit cluttered/hard to follow.  This attempts to break the functionality up a bit better (moves caching into its own class).

Few functionality changes also:

- Hoists currently selected binary to top of list when choosing
- `cadence.changeCadenceVersion` command was a bit of a misnomer which came from the initial vision of this feature (but has deviated since).  This was changed to `cadence.changeFlowCliBinary`
- Also fixes a bug where the CLI version selection would break if an invalid flow command was configured at startup.
- Fixes "bug" when not in workspace folder

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
