### PR TITLE
Use Homebrew to check for latest Flow CLI version

### DIFF
--- a/extension/src/dependency-installer/installers/flow-cli-installer.ts
+++ b/extension/src/dependency-installer/installers/flow-cli-installer.ts
@@ -8,6 +8,12 @@ import fetch from 'node-fetch'
 import { HomebrewInstaller } from './homebrew-installer'
 import { KNOWN_FLOW_COMMANDS } from '../../flow-cli/cli-versions-provider'
 
+type HomebrewVersionInfo = {
+  versions: {
+    stable: string
+  }
+}
+
 // Command to check flow-cli
 const COMPATIBLE_FLOW_CLI_VERSIONS = '>=1.6.0'
 
@@ -21,7 +27,8 @@ const BASH_INSTALL_FLOW_CLI = (githubToken?: string): string =>
   `${
     githubToken != null ? `GITHUB_TOKEN=${githubToken} ` : ''
   }sh -ci "$(curl -fsSL https://raw.githubusercontent.com/onflow/flow-cli/master/install.sh)"`
-const VERSION_INFO_URL = 'https://raw.githubusercontent.com/onflow/flow-cli/master/version.txt'
+const VERSION_INFO_URL = 'https://formulae.brew.sh/api/formula/flow-cli.json'
+
 export class InstallFlowCLI extends Installer {
   #githubToken: string | undefined
   #context: InstallerContext
@@ -79,22 +86,26 @@ export class InstallFlowCLI extends Installer {
   }
 
   async findLatestVersion (currentVersion: semver.SemVer): Promise<void> {
-    const response = await fetch(VERSION_INFO_URL)
-    const latestStr = semver.clean(await response.text())
-    const latest: semver.SemVer | null = semver.parse(latestStr)
-
-    // Check if latest version > current version
-    if (latest != null && latestStr != null && semver.compare(latest, currentVersion) === 1) {
-      promptUserInfoMessage(
-        'There is a new Flow CLI version available: ' + latestStr,
-        [{
-          label: 'Install latest Flow CLI',
-          callback: async () => {
-            await this.runInstall()
-            await this.#context.refreshDependencies()
-          }
-        }]
-      )
+    try {
+      const response = await fetch(VERSION_INFO_URL)  
+      const { versions: {stable: latestStr} }: HomebrewVersionInfo = await response.json()
+      const latest: semver.SemVer | null = semver.parse(latestStr)
+  
+      // Check if latest version > current version
+      if (latest != null && latestStr != null && semver.compare(latest, currentVersion) === 1) {
+        promptUserInfoMessage(
+          'There is a new Flow CLI version available: ' + latest.format(),
+          [{
+            label: 'Install latest Flow CLI',
+            callback: async () => {
+              await this.runInstall()
+              await this.#context.refreshDependencies()
+            }
+          }]
+        )
+      }
+    } catch(e) {
+      // swallow the error, it doesn't matter if we can't perform the check
     }
   }
 


### PR DESCRIPTION
Closes #599 

## Description

Switch away with soon to be deprecated `version.txt`

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
